### PR TITLE
Add prowjobs for EKS Distro base, charts and projects

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro-build-tooling:
+  - name: eks-distro-base-postsubmit
+    always_run: false
+    run_if_changed: "eks-distro-base/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro-build-tooling:
+  - name: eks-distro-base-presubmit
+    always_run: false
+    run_if_changed: "eks-distro-base/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C eks-distro-base DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-chart-postsubmits.yaml
@@ -1,0 +1,26 @@
+postsubmits:
+  aws/eks-distro-build-tooling:
+  - name: eks-distro-chart-postsubmit
+    always_run: false
+    run_if_changed: "eks-distro-chart/*"
+    cluster: "prow-jobs-cluster"
+    max_concurrency: 10
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
+    spec:
+      serviceaccountName: charts-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C eks-distro-chart
+

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-chart-presubmits.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  aws/eks-distro-build-tooling:
+  - name: eks-distro-chart-presubmit
+    always_run: false
+    run_if_changed: "eks-distro-chart/*"
+    cluster: "prow-jobs-cluster"
+    max_concurrency: 10
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make verify -C eks-distro-chart
+

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -1,0 +1,56 @@
+postsubmits:
+  aws/eks-distro:
+  - name: aws-iam-authenticator-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-sigs/aws-iam-authenticator DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -1,0 +1,54 @@
+presubmits:
+  aws/eks-distro:
+  - name: aws-iam-authenticator-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-sigs/aws-iam-authenticator DEVELOPMENT=false
+          &&
+          mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -1,0 +1,28 @@
+postsubmits:
+  aws/eks-distro:
+  - name: cni-plugins-postsubmit
+    always_run: false
+    run_if_changed: "projects/containernetworking/plugins/*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/containernetworking/plugins
+          &&
+          mv ./projects/containernetworking/plugins/_output/tar/* /logs/artifacts
+

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  aws/eks-distro:
+  - name: cni-plugins-presubmit
+    always_run: false
+    run_if_changed: "projects/containernetworking/plugins/*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/containernetworking/plugins
+          &&
+          mv ./projects/containernetworking/plugins/_output/tar/* /logs/artifacts
+

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: coredns-postsubmit
+    always_run: false
+    run_if_changed: "projects/coredns/coredns/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/coredns/coredns DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: coredns-presubmit
+    always_run: false
+    run_if_changed: "projects/coredns/coredns/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/coredns/coredns DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -1,0 +1,56 @@
+postsubmits:
+  aws/eks-distro:
+  - name: etcd-postsubmit
+    always_run: false
+    run_if_changed: "projects/etcd-io/etcd/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/etcd-io/etcd DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -1,0 +1,54 @@
+presubmits:
+  aws/eks-distro:
+  - name: etcd-presubmit
+    always_run: false
+    run_if_changed: "projects/etcd-io/etcd/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/etcd-io/etcd DEVELOPMENT=false
+          &&
+          mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: external-attacher-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-attacher/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/external-attacher DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: external-attacher-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-attacher/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/external-attacher DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: external-provisioner-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-provisioner/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/external-provisioner DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: external-provisioner-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-provisioner/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/external-provisioner DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: external-resizer-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-resizer/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/external-resizer DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: external-resizer-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-resizer/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/external-resizer DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: external-snapshotter-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-snapshotter/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/external-snapshotter DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: external-snapshotter-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/external-snapshotter/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/external-snapshotter DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -1,0 +1,57 @@
+postsubmits:
+  aws/eks-distro:
+  - name: kubernetes-1-18-postsubmit
+    always_run: false
+    # TODO: tweak to only run if Makefile, build, release branch files change
+    run_if_changed: "projects/kubernetes/kubernetes/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes/kubernetes DEVELOPMENT=false RELEASE_BRANCH=1-18 IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          mv ./projects/kubernetes/kubernetes/_output/1-18/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -1,0 +1,55 @@
+presubmits:
+  aws/eks-distro:
+  - name: kubernetes-1-18-presubmit
+    always_run: false
+    # TODO: tweak to only run if Makefile, build, release branch files change
+    run_if_changed: "projects/kubernetes/kubernetes/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes/kubernetes DEVELOPMENT=false RELEASE_BRANCH=1-18
+          &&
+          mv ./projects/kubernetes/kubernetes/_output/1-18/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: kubernetes-release-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes/release/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes/release DEVELOPMENT=false GO_RUNNER_IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' KUBE_PROXY_BASE_IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: kubernetes-release-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes/release/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes/release DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: livenessprobe-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/livenessprobe/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/livenessprobe DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: livenessprobe-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/livenessprobe/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/livenessprobe DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: main-presubmit
+    always_run: false
+    run_if_changed: "^Makefile$"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: metrics-server-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-sigs/metrics-server/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-sigs/metrics-server DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: metrics-server-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-sigs/metrics-server/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - sh
+        - -c
+        - >
+          make build -C projects/kubernetes-sigs/metrics-server DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -1,0 +1,54 @@
+postsubmits:
+  aws/eks-distro:
+  - name: node-driver-registrar-postsubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/node-driver-registrar/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpostsubmitsbucket526-ut9o51ly3595
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/kubernetes-csi/node-driver-registrar DEVELOPMENT=false IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)'
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -1,0 +1,52 @@
+presubmits:
+  aws/eks-distro:
+  - name: node-driver-registrar-presubmit
+    always_run: false
+    run_if_changed: "projects/kubernetes-csi/node-driver-registrar/.*"
+    max_concurrency: 10
+    cluster: "prow-jobs-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316-prowpresubmitsbucket7203-1swi49tnwncy8
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    clone_uri: "git@github.com:aws/eks-distro.git"
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:51f42f4402f38946eb23884a32a2541b8ac6edca
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-csi/node-driver-registrar DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -42,7 +42,4 @@ presets:
     emptyDir: {}
   - name: status
     emptyDir: {}
-#- env:
-#  name: GOPROXY
-#  value: http://athens-proxy.default.svc.cluster.local
 


### PR DESCRIPTION
Added prowjobs to build EKS distro base image, push charts and build EKS Distro projects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
