### PR TITLE
Remove branch configuration for presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-chart-presubmits.yaml
@@ -5,8 +5,6 @@ presubmits:
     run_if_changed: "eks-distro-chart/*"
     cluster: "prow-jobs-cluster"
     max_concurrency: 10
-    branches:
-    - ^main$
     skip_report: false
     decoration_config:
       gcs_configuration:


### PR DESCRIPTION
Removing this as don't need this configuration for a presubmit job.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
