### PR TITLE
Add Apache 2.0 License headers

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro-build-tooling:
   - name: builder-base-postsubmit

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro-build-tooling:
   - name: builder-base-presubmit

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-postsubmit

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-presubmit

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro-build-tooling:
   - name: helm-chart-postsubmit

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro-build-tooling:
   - name: helm-chart-presubmit

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-postsubmit

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-presubmit

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: cni-plugins-postsubmit

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: cni-plugins-presubmit

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: coredns-postsubmit

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: coredns-presubmit

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: etcd-postsubmit

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: etcd-presubmit

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: external-attacher-postsubmit

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: external-attacher-presubmit

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: external-provisioner-postsubmit

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: external-provisioner-presubmit

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: external-resizer-postsubmit

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: external-resizer-presubmit

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: external-snapshotter-postsubmit

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: external-snapshotter-presubmit

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: kubernetes-1-18-postsubmit

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: kubernetes-1-18-presubmit

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: kubernetes-release-postsubmit

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: kubernetes-release-presubmit

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: livenessprobe-postsubmit

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: livenessprobe-presubmit

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: main-presubmit

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: metrics-server-postsubmit

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: metrics-server-presubmit

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 postsubmits:
   aws/eks-distro:
   - name: node-driver-registrar-postsubmit

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presubmits:
   aws/eks-distro:
   - name: node-driver-registrar-presubmit

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 presets:
 - labels:
     image-build: "true"

--- a/scripts/buildkitd-entrypoint.sh
+++ b/scripts/buildkitd-entrypoint.sh
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run buildkitd in background mode to be able to poll
 # for the done status file and kill process after
 rootlesskit \


### PR DESCRIPTION
Add Apache 2.0 License headers, just like https://github.com/aws/eks-distro/pull/12


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
