### PR TITLE
Give k8s presubmits more resources

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -50,6 +50,13 @@ presubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          requests:
+            memory: "27Gi"
+            cpu: "3584m"
+          limits:
+            memory: "27Gi"
+            cpu: "3584m"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -66,4 +73,10 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "512m"
+          limits:
+            memory: "1Gi"
+            cpu: "512m"

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -47,6 +47,13 @@ presubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          requests:
+            memory: "27Gi"
+            cpu: "3584m"
+          limits:
+            memory: "27Gi"
+            cpu: "3584m"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -63,4 +70,10 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "512m"
+          limits:
+            memory: "1Gi"
+            cpu: "512m"


### PR DESCRIPTION
Uses the largest task size available
* https://aws.amazon.com/fargate/pricing/
* https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
