### PR TITLE
Reduce Fargate Task Size

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -52,10 +52,10 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "27Gi"
+            memory: "26Gi"
             cpu: "3584m"
           limits:
-            memory: "27Gi"
+            memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
         image: moby/buildkit:master-rootless
@@ -76,7 +76,7 @@ presubmits:
         resources:
           requests:
             memory: "1Gi"
-            cpu: "512m"
+            cpu: "256m"
           limits:
             memory: "1Gi"
-            cpu: "512m"
+            cpu: "256m"

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -49,10 +49,10 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "27Gi"
+            memory: "26Gi"
             cpu: "3584m"
           limits:
-            memory: "27Gi"
+            memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
         image: moby/buildkit:master-rootless
@@ -73,7 +73,7 @@ presubmits:
         resources:
           requests:
             memory: "1Gi"
-            cpu: "512m"
+            cpu: "256m"
           limits:
             memory: "1Gi"
-            cpu: "512m"
+            cpu: "256m"


### PR DESCRIPTION
Should resolve error of
```yaml
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-11-27T23:16:28Z"
    message: Your pod's cpu/memory requirements exceed the max Fargate configuration
    reason: POD_CPU_MEM_EXCEEDS_MAX_FARGATE_SIZE
    status: "False"
    type: PodScheduled
  phase: Pending
  qosClass: Burstable
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
