### PR TITLE
Give CPU to sidecars

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -52,10 +52,10 @@ presubmits:
         resources:
           requests:
             memory: "8Gi"
-            cpu: "2048m"
+            cpu: "1536m"
           limits:
             memory: "8Gi"
-            cpu: "2048m"
+            cpu: "1536m"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -75,8 +75,8 @@ presubmits:
         resources:
           requests:
             memory: "8Gi"
-            cpu: "2048m"
+            cpu: "1536m"
           limits:
             memory: "8Gi"
-            cpu: "2048m"
+            cpu: "1536m"
 


### PR DESCRIPTION
All 4 CPUs on largest FG task size were being allocated to 2 containers, not leaving any for sidecars


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
