### PR TITLE
Builder now has gcc

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -29,12 +29,16 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c
         - >
+          make test -C release/
+          &&
           make build -C release/
+          &&
+          mv ./release/cover.out /logs/artifacts/filtered.cov
         resources:
           requests:
             memory: "3584Mi"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -32,7 +32,7 @@ postsubmits:
       serviceaccountName: release-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/docs-presubmit.yaml
+++ b/jobs/aws/eks-distro/docs-presubmit.yaml
@@ -30,7 +30,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - sh
         - -c

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ac068ea9b78d3e2909e325ebfc272e5b31b1c37
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
         command:
         - bash
         - -c


### PR DESCRIPTION
Bump builder image, add `make test` to release tooling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
