### PR TITLE
Switched to credHelpers instead of credStore

### DIFF
--- a/config/docker-ecr-config.json
+++ b/config/docker-ecr-config.json
@@ -1,1 +1,8 @@
-{ "credsStore": "ecr-login" }
+{
+    "credHelpers": {
+        "316434458148.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
+        "862665599504.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
+        "137112412989.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
+        "520703868821.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
+    }
+}


### PR DESCRIPTION
This is required to support static tokens for ecr-public until `ecr-credential-helper` has ecr-public support

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
