### PR TITLE
Remove clone_uri from jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     labels:
       image-build: "true"
     spec:
@@ -67,4 +66,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     labels:
       image-build: "true"
     spec:
@@ -79,4 +78,3 @@ presubmits:
           limits:
             memory: "8Gi"
             cpu: "1536m"
-

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     spec:
       serviceaccountName: charts-build-account
       containers:
@@ -37,4 +36,3 @@ postsubmits:
         - -c
         - >
           make release -C helm-charts
-

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     spec:
       serviceaccountName: presubmits-build-account
       containers:
@@ -42,4 +41,3 @@ presubmits:
           limits:
             memory: "2Gi"
             cpu: "512m"
-

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro-build-tooling.git"
     spec:
       serviceaccountName: presubmits-build-account
       containers:
@@ -46,4 +45,3 @@ presubmits:
           limits:
             memory: "3584Mi"
             cpu: "1024m"
-

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -67,4 +66,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -72,4 +71,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:
@@ -39,4 +38,3 @@ postsubmits:
           make release -C projects/containernetworking/plugins
           &&
           mv ./projects/containernetworking/plugins/_output/tar/* /logs/artifacts
-

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     spec:
       serviceaccountName: release-build-account
       containers:

--- a/jobs/aws/eks-distro/docs-presubmit.yaml
+++ b/jobs/aws/eks-distro/docs-presubmit.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -67,4 +66,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -72,4 +71,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -28,7 +28,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -68,4 +67,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -26,7 +26,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -27,7 +27,6 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -65,4 +64,3 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -25,7 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    clone_uri: "git@github.com:aws/eks-distro.git"
     labels:
       image-build: "true"
     spec:
@@ -70,4 +69,3 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -56,4 +56,3 @@ presets:
     emptyDir: {}
   - name: status
     emptyDir: {}
-


### PR DESCRIPTION
Remove clone_uri from jobs as we will be making the repos public. 

This should only be merged after we mark the repos as public.

/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
