### PR TITLE
Add periodic to check for updates and build new base image

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -1,0 +1,91 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+periodics:
+- name: eks-distro-base-periodic
+  labels:
+    image-build: "true"
+  # Runs every weekday (M-F) at 10am PST
+  cron: "* 18 * * 1-5"
+  cluster: "prow-postsubmits-cluster"
+  decoration_config:
+    gcs_configuration:
+      bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+      path_strategy: explicit
+    s3_credentials_secret: s3-credentials
+  extra_refs:
+  - org: eks-distro-pr-bot
+    repo: eks-distro-build-tooling
+    base_ref: main
+  - org: eks-distro-pr-bot
+    repo: eks-distro
+    base_ref: main
+  spec:
+    serviceaccountName: periodics-build-account
+    containers:
+    - name: build-container
+      image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
+      command:
+      - bash
+      - -c
+      - >
+        ./eks-distro-base/check_and_update.sh
+        &&
+        touch /status/done;
+      volumeMounts:
+      - name: ssh-auth
+        mountPath: /secrets/ssh-secrets
+        readOnly: true
+      - name: github-auth
+        mountPath: /secrets/github-secrets
+        readOnly: true
+      livenessProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - date +%s > /status/pending
+        periodSeconds: 10
+    - name: buildkitd
+      image: moby/buildkit:master-rootless
+      command:
+      - sh
+      args:
+      - /script/entrypoint.sh
+      volumeMounts:
+      - name: ssh-auth
+        mountPath: /secrets/ssh-secrets
+        readOnly: true
+      - name: github-auth
+        mountPath: /secrets/github-secrets
+        readOnly: true
+      livenessProbe:
+        exec:
+          command:
+          - sh
+          - -c
+          - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+        periodSeconds: 15
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    volumes:
+    - name: ssh-auth
+      secret:
+        defaultMode: 256
+        secretName: pr-bot-ssh-secret
+    - name: github-auth
+      secret:
+        defaultMode: 256
+        secretName: pr-bot-github-token


### PR DESCRIPTION
The EKS-D base `periodic` job runs every weekday (Monday to Friday) at 10am PST. It runs scripts to check if there are available `yum` updates on the latest EKS Distro base image, and if available, it triggers a new base image build and creates PR's to the respective repos to replace the new image tag in the respective files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
