### PR TITLE
Change cron to run only at the hour mark

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -16,8 +16,8 @@ periodics:
 - name: eks-distro-base-periodic
   labels:
     image-build: "true"
-  # Runs every weekday (M-F) at 10am PST
-  cron: "* 18 * * 1-5"
+  # Runs every weekday (M-F) at 11am PST
+  cron: "0 19 * * 1-5"
   cluster: "prow-postsubmits-cluster"
   decoration_config:
     gcs_configuration:


### PR DESCRIPTION
Run periodic only at the 11am PST.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
