### PR TITLE
Use regional endpoints for docs uploads

### DIFF
--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -32,6 +32,13 @@ postsubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
+        env:
+        - name: AWS_STS_REGIONAL_ENDPOINTS
+          value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         command:
         - bash
         - -c

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -17,7 +17,7 @@ presets:
     image-build: "true"
   env:
   - name: AWS_SDK_LOAD_CONFIG
-    value: true
+    value: "true"
   - name: AWS_STS_REGIONAL_ENDPOINTS
     value: regional
   - name: AWS_ROLE_SESSION_NAME


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Make docs uploads use regional endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
