### PR TITLE
Invoke PR creation script to change base image tags after every new build

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -21,6 +21,13 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     branches:
     - ^main$
+    extra_refs:
+    - org: eks-distro-pr-bot
+      repo: eks-distro-build-tooling
+      base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-distro-prow-jobs
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -21,6 +21,13 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     branches:
     - ^main$
+    extra_refs:
+    - org: eks-distro-pr-bot
+      repo: eks-distro-build-tooling
+      base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-distro
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:
@@ -38,7 +45,9 @@ postsubmits:
         - bash
         - -c
         - >
-          make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          export DATE_EPOCH=$(date "+%F-%s")
+          &&
+          make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=${DATE_EPOCH}
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
Call the script to create PR's for the new builder-base and eks-distro-base image tag which get generated during the postsubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
