### PR TITLE
Add secret volume mounts to base postsubmits for Github authentication

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -50,6 +50,13 @@ postsubmits:
           make release -C builder-base DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done
+        volumeMounts:
+        - name: ssh-auth
+          mountPath: /secrets/ssh-secrets
+          readOnly: true
+        - name: github-auth
+          mountPath: /secrets/github-secrets
+          readOnly: true
         livenessProbe:
           exec:
             command:
@@ -63,6 +70,13 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
+        volumeMounts:
+        - name: ssh-auth
+          mountPath: /secrets/ssh-secrets
+          readOnly: true
+        - name: github-auth
+          mountPath: /secrets/github-secrets
+          readOnly: true
         livenessProbe:
           exec:
             command:
@@ -73,3 +87,12 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
+      volumes:
+      - name: ssh-auth
+        secret:
+          defaultMode: 256
+          secretName: pr-bot-ssh-secret
+      - name: github-auth
+        secret:
+          defaultMode: 256
+          secretName: pr-bot-github-token

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -50,6 +50,13 @@ postsubmits:
           make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=${DATE_EPOCH}
           &&
           touch /status/done
+        volumeMounts:
+          - name: ssh-auth
+            mountPath: /secrets/ssh-secrets
+            readOnly: true
+          - name: github-auth
+            mountPath: /secrets/github-secrets
+            readOnly: true
         livenessProbe:
           exec:
             command:
@@ -63,6 +70,13 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
+        volumeMounts:
+          - name: ssh-auth
+            mountPath: /secrets/ssh-secrets
+            readOnly: true
+          - name: github-auth
+            mountPath: /secrets/github-secrets
+            readOnly: true
         livenessProbe:
           exec:
             command:
@@ -73,3 +87,12 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
+      volumes:
+      - name: ssh-auth
+        secret:
+          defaultMode: 256
+          secretName: pr-bot-ssh-secret
+      - name: github-auth
+        secret:
+          defaultMode: 256
+          secretName: pr-bot-github-token


### PR DESCRIPTION
We need to mount secrets on the jobs for authenticating with Github and `gh` client.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
