### PR TITLE
Add eks token expiration annotation to jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: charts-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -36,6 +36,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -24,6 +24,8 @@ periodics:
       bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
+  annotations:
+    eks.amazonaws.com/token-expiration: "3600"
   extra_refs:
   - org: eks-distro-pr-bot
     repo: eks-distro-build-tooling

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -36,6 +36,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -34,6 +34,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -27,6 +27,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: charts-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -27,6 +27,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -27,6 +27,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: docs-build-account
       containers:

--- a/jobs/aws/eks-distro/docs-presubmit.yaml
+++ b/jobs/aws/eks-distro/docs-presubmit.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -30,6 +30,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "7200"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -28,6 +28,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "14400"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "14400"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -29,6 +29,8 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: postsubmits-build-account
       containers:

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+    annotations:
+      eks.amazonaws.com/token-expiration: "3600"
     spec:
       serviceaccountName: presubmits-build-account
       containers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding the eks token expiration annotation to our jobs to limit the token expiration more than the default of 24 hours.

The kubernetes jobs have different expirations (2 hours for postsubmits and 4 hours for presubmits) to accommodate for the longer run time, while all other jobs have the lowest expiration possible (which is 1 hour).

This cannot be merged until we have our infra commit merged and deployed to our cluster first.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
