### PR TITLE
Add extra refs to presubmit for builder-base PR automation dry run

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -19,6 +19,13 @@ presubmits:
     run_if_changed: "builder-base/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
+    extra_refs:
+    - org: eks-distro-pr-bot
+      repo: eks-distro-build-tooling
+      base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-distro-prow-jobs
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:


### PR DESCRIPTION
Cloning the PR bot accounts to dry-run PR automation in builder-base presubmit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
