### PR TITLE
Use make invocation in periodic for consistency

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -40,7 +40,7 @@ periodics:
       - bash
       - -c
       - >
-        ./eks-distro-base/check_update.sh
+        make update -C eks-distro-base
         &&
         touch /status/done;
       volumeMounts:


### PR DESCRIPTION
Calling a make target in periodic instead of script to be consistent with other prowjobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
