### PR TITLE
Add linting presubmit for prowjobs

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -1,0 +1,46 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro-prow-jobs:
+  - name: prowjobs-lint-presubmit
+    always_run: false
+    run_if_changed: "jobs/aws/.*"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3
+        command:
+        - bash
+        - -c
+        - >
+          go run scripts/lint_prowjobs.go
+      resources:
+        requests:
+          memory: "4Gi"
+          cpu: "1024m"
+        limits:
+          memory: "4Gi"
+          cpu: "1024m"


### PR DESCRIPTION
Adding linting presubmit to validate prowjobs. A test script will be added on a follow-up PR. When a PR is raised to add new jobs or change existing jobs, the script runs checks to determine if the added jobs have the proper configuration of buckets, clusters, service accounts, `make` targets, `always_run` and `skip_report` flags, etc. These checks are separate for presubmits and postsubmits. The script also outputs the necessary fixes that need to be made.

This presubmit will be an additional validation test for the jobs we add to the prowjobs repo, i.e., it will catch the common errors like incorrect bucketname/cluster for the job type, which a human reviewer may miss when reviewing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
