### PR TITLE
Export Github org information in periodic to enable automatic PR creation

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -25,6 +25,9 @@ periodics:
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   extra_refs:
+  - org: aws
+    repo: eks-distro-build-tooling
+    base_ref: main
   - org: eks-distro-pr-bot
     repo: eks-distro-build-tooling
     base_ref: main
@@ -43,6 +46,9 @@ periodics:
         make update -C eks-distro-base
         &&
         touch /status/done;
+      env:
+      - name: REPO_OWNER
+        value: "aws"
       volumeMounts:
       - name: ssh-auth
         mountPath: /secrets/ssh-secrets


### PR DESCRIPTION
In presubmits and postsubmits, the `REPO_OWNER` variable is available in the CI environment. But since periodics are not tied to a particular GitHub repo, we need to export the `REPO_OWNER` explicitly. Also we need to clone the aws/eks-distro-build-tooling repo since that is the source of the automation scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
