### PR TITLE
Fix indentation to apply resource requirements to job container

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -37,10 +37,10 @@ presubmits:
         - -c
         - >
           go run scripts/lint_prowjobs.go
-      resources:
-        requests:
-          memory: "4Gi"
-          cpu: "1024m"
-        limits:
-          memory: "4Gi"
-          cpu: "1024m"
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1024m"
+          limits:
+            memory: "4Gi"
+            cpu: "1024m"


### PR DESCRIPTION
Fixed indentation so that resources are specified under `.spec.containers[].resources`. The requests and limits will now be applied to the container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
