### PR TITLE
Adding Prow jobs for Prometheus charts

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: prometheus-helm-chart-tooling-postsubmit
     always_run: false
-    run_if_changed: 'helm-charts/.*|projects/prometheus-community/helm-charts/.*'
+    run_if_changed: 'projects/prometheus-community/helm-charts/.*'
     cluster: "prow-postsubmits-cluster"
     max_concurrency: 10
     branches:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+postsubmits:
+  aws/eks-distro-build-tooling:
+  - name: helm-chart-tooling-postsubmit
+    always_run: false
+    run_if_changed: 'helm-charts/.*|projects/prometheus-community/helm-charts/.*'
+    cluster: "prow-postsubmits-cluster"
+    max_concurrency: 10
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: charts-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:89f14256cd7775881251aeb85900cf7835f711a4
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/prometheus-community/helm-charts

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -14,7 +14,7 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: helm-chart-tooling-postsubmit
+  - name: prometheus-helm-chart-tooling-postsubmit
     always_run: false
     run_if_changed: 'helm-charts/.*|projects/prometheus-community/helm-charts/.*'
     cluster: "prow-postsubmits-cluster"

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: prometheus-helm-chart-tooling-presubmit
     always_run: false
-    run_if_changed: 'helm-charts/.*|projects/prometheus-community/helm-charts/.*'
+    run_if_changed: 'helm-charts/scripts/.*|projects/prometheus-community/helm-charts/.*'
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro-build-tooling:
+  - name: prometheus-helm-chart-tooling-presubmit
+    always_run: false
+    run_if_changed: 'helm-charts/.*|projects/prometheus-community/helm-charts/.*'
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: presubmits-build-account
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:89f14256cd7775881251aeb85900cf7835f711a4
+        command:
+        - bash
+        - -c
+        - >
+          make verify -C projects/prometheus-community/helm-charts
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "512m"
+          limits:
+            memory: "2Gi"
+            cpu: "512m"


### PR DESCRIPTION
*Description of changes:*
Adding presubmit and postsubmit prow jobs to build helm charts for Prometheus.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
