### PR TITLE
Change directory for linting script invocation

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
         - bash
         - -c
         - >
-          go run scripts/lint_prowjobs.go
+          go run scripts/lint_prowjobs/main.go
         resources:
           requests:
             memory: "4Gi"


### PR DESCRIPTION
The linting script, when merged, will be located under `scripts/lint_prowjobs/main.go` (https://github.com/aws/eks-distro-prow-jobs/pull/58#discussion_r552820228). Hence the prowjob needs to be modified to invoke it from there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
