### PR TITLE
Remove unwanted label from lint presubmit

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -25,8 +25,6 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    labels:
-      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       containers:


### PR DESCRIPTION
This label was causing the Athens proxy to be set for the lint presubmit, which caused the job to run indefinitely long. Removing the label should fix the issue. Also there are no images built by this prowjob so the label is not appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
