### PR TITLE
Use go vet to ensure script is linted before running

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -34,6 +34,8 @@ presubmits:
         - bash
         - -c
         - >
+          go vet scripts/lint_prowjobs/main.go
+          &&
           go run scripts/lint_prowjobs/main.go
         resources:
           requests:


### PR DESCRIPTION
It would be a good idea to run `go vet` on the linting code itself to look for errors, prior to running it. Passing in file name since the file is not in GOROOT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
