### PR TITLE
Fix make target comparison block, print filenames only for jobs with errors

### DIFF
--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -150,12 +150,18 @@ func PresubmitMakeTargetCheck(jc *JobConstants) presubmitCheck {
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+) .*`).FindStringSubmatch(strings.Join(presubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
-		if strings.Contains(presubmitConfig.JobBase.Name, "cni") && jobMakeTarget != jc.CniMakeTarget {
-			return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.CniMakeTarget)
-		} else if strings.Contains(presubmitConfig.JobBase.Name, "helm-chart") && jobMakeTarget != jc.HelmMakeTarget {
-			return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.HelmMakeTarget)
-		} else if strings.Contains(presubmitConfig.JobBase.Name, "release-tooling") && jobMakeTarget != jc.ReleaseToolingMakeTarget {
-			return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.ReleaseToolingMakeTarget)
+		if strings.Contains(presubmitConfig.JobBase.Name, "cni") {
+			if jobMakeTarget != jc.CniMakeTarget {
+				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.CniMakeTarget)
+			}
+		} else if strings.Contains(presubmitConfig.JobBase.Name, "helm-chart") {
+			if jobMakeTarget != jc.HelmMakeTarget {
+				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.HelmMakeTarget)
+			}
+		} else if strings.Contains(presubmitConfig.JobBase.Name, "release-tooling") {
+			if jobMakeTarget != jc.ReleaseToolingMakeTarget {
+				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.ReleaseToolingMakeTarget)
+			}
 		} else if jobMakeTarget != jc.DefaultMakeTarget {
 			return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.DefaultMakeTarget)
 		}
@@ -165,6 +171,9 @@ func PresubmitMakeTargetCheck(jc *JobConstants) presubmitCheck {
 
 func PostsubmitMakeTargetCheck(jc *JobConstants) postsubmitCheck {
 	return postsubmitCheck(func(postsubmitConfig config.Postsubmit, fileContentsString string) (bool, int, string) {
+		if strings.Contains(postsubmitConfig.JobBase.Name, "kops") {
+			return true, 0, ""
+		}
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+) .*`).FindStringSubmatch(strings.Join(postsubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
@@ -216,11 +225,11 @@ func displayConfigErrors(fileErrorMap map[string][]string) bool {
 	for file, configErrors := range fileErrorMap {
 		if len(configErrors) > 0 {
 			errorsExist = true
-		}
-		fmt.Println()
-		fmt.Printf("\n%s:\n", file)
-		for _, errorString := range configErrors {
-			fmt.Fprintln(w, errorString)
+			fmt.Println()
+			fmt.Printf("\n%s:\n", file)
+			for _, errorString := range configErrors {
+				fmt.Fprintln(w, errorString)
+			}
 		}
 	}
 	w.Flush()


### PR DESCRIPTION
- Split up make comparson block into nested if-blocks for appropriate make target testing.
- Skipping checks for kops postsubmit which does not invoke `make` commands
- Printing filenames only if errors found.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
