### PR TITLE
Change prowjob trigger condition for projects depending on eks-distro-base image

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: athens-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/gomods/athens/*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/*"
     cluster: "prow-postsubmits-cluster"
     max_concurrency: 10
     branches:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: athens-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/gomods/athens/*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: coredns-postsubmit
     always_run: false
-    run_if_changed: "projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: coredns-presubmit
     always_run: false
-    run_if_changed: "projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: etcd-postsubmit
     always_run: false
-    run_if_changed: "projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: etcd-presubmit
     always_run: false
-    run_if_changed: "projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: external-attacher-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-attacher/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-attacher/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-attacher-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-attacher/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-attacher/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: external-provisioner-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-provisioner/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-provisioner/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-provisioner-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-provisioner/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-provisioner/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: external-resizer-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-resizer/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-resizer/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-resizer-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-resizer/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-resizer/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: external-snapshotter-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-snapshotter/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-snapshotter/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-snapshotter-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/external-snapshotter/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/external-snapshotter/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: kubernetes-release-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-release-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: livenessprobe-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/livenessprobe/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/livenessprobe/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: livenessprobe-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/livenessprobe/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/livenessprobe/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: main-presubmit
     always_run: false
-    run_if_changed: "^Makefile$"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^Makefile$"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: metrics-server-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: metrics-server-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: node-driver-registrar-postsubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/node-driver-registrar/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/node-driver-registrar/.*"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: node-driver-registrar-presubmit
     always_run: false
-    run_if_changed: "projects/kubernetes-csi/node-driver-registrar/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-csi/node-driver-registrar/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false


### PR DESCRIPTION
When [this](https://github.com/aws/eks-distro/pull/122) PR is merged, we will have the EKS distro base tag file in a separate file at the root of the repo instead of the individual Makefiles under each project. We should trigger new builds of these projects every time this tag file changes, since it means we have a new base image to build our projects on. This is achieved by adding the tag file to the `run_if_changed` field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
