### PR TITLE
Have CNI presubmit just call build

### DIFF
--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -34,9 +34,7 @@ presubmits:
         - bash
         - -c
         - >
-          make release -C projects/containernetworking/plugins
-          &&
-          mv ./projects/containernetworking/plugins/_output/tar/* /logs/artifacts
+          make build -C projects/containernetworking/plugins
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
Have the CNI presubmit just call the build target because we don't want to save any artifacts from the build. Also, remove the move command to the log artifacts as we will not be using that either.