### PR TITLE
Increase timeout

### DIFF
--- a/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
@@ -23,6 +23,7 @@ postsubmits:
     - ^main$
     skip_report: false
     decoration_config:
+      timeout: 4h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
@@ -23,6 +23,7 @@ postsubmits:
     - ^main$
     skip_report: false
     decoration_config:
+      timeout: 4h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -21,6 +21,7 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
+      timeout: 4h
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit


### PR DESCRIPTION
Main-postsubmits are failing since they run longer than the 2hr default timeout value mentioned [here](https://github.com/kubernetes/test-infra/blob/master/prow/entrypoint/run.go#L164-L167). We can override the timeout values that get applied to the entrypoint pod utility by setting it explicitly in the job's [decoration config](https://github.com/kubernetes/test-infra/blob/master/prow/apis/prowjobs/v1/types.go#L328-L330).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
