### PR TITLE
Modify bucket name for artifacts for postsubmits

### DIFF
--- a/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
@@ -40,7 +40,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-18 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-18 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
@@ -40,7 +40,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-19 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-19 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modfiying name of the bucket to workaround the kops issue for now. Needs to be merged once S3 bucket is deployed through CDK.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
