### PR TITLE
Push to one release repo

### DIFF
--- a/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-18-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
   - name: main-1-18-postsubmit
     always_run: false
     run_if_changed: ".*"
-    max_concurrency: 10
+    max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:
     - ^main$
@@ -40,7 +40,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-18 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
+          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-18 ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/main-1-19-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
   - name: main-1-19-postsubmit
     always_run: false
     run_if_changed: ".*"
-    max_concurrency: 10
+    max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:
     - ^main$
@@ -40,7 +40,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-19 RELEASE=$(git rev-parse --short HEAD) IMAGE_TAG='$(GIT_TAG)-$(PULL_BASE_SHA)' ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
+          make postsubmit-conformance DEVELOPMENT=false RELEASE_BRANCH=1-19 ARTIFACT_BUCKET=eks-d-postsubmit-artifacts
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
To simplify things, it would be a lot easier if we just pushed the latest changes to the current release s3 bucket and ECR repo.