### PR TITLE
Fix make target for release postsubmits

### DIFF
--- a/jobs/aws/eks-distro/release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/release-1-18-postsubmits.yaml
@@ -46,7 +46,7 @@ postsubmits:
         - >
           source release/prow.sh
           &&
-          make setup release DEVELOPMENT=false RELEASE_BRANCH=1-18 ARTIFACT_BUCKET=artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2 IMAGE_REPO=public.ecr.aws/eks-distro
+          make release DEVELOPMENT=false RELEASE_BRANCH=1-18 ARTIFACT_BUCKET=artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2 IMAGE_REPO=public.ecr.aws/eks-distro
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro/release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/release-1-19-postsubmits.yaml
@@ -46,7 +46,7 @@ postsubmits:
         - >
           source release/prow.sh
           &&
-          make setup release DEVELOPMENT=false RELEASE_BRANCH=1-19 ARTIFACT_BUCKET=artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2 IMAGE_REPO=public.ecr.aws/eks-distro
+          make release DEVELOPMENT=false RELEASE_BRANCH=1-19 ARTIFACT_BUCKET=artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2 IMAGE_REPO=public.ecr.aws/eks-distro
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
The `setup` target is invoked as a [prerequisite](https://github.com/aws/eks-distro/blob/main/Makefile#L70) of the `release` target in the Makefile. Hence we do not need to invoke it separately on the release postsubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
