### PR TITLE
Skip make target check for release postsubmits

### DIFF
--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -170,7 +170,9 @@ func PostsubmitMakeTargetCheck(jc *JobConstants) postsubmitCheck {
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?) .*`).FindStringSubmatch(strings.Join(postsubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
-		if strings.Contains(postsubmitConfig.JobBase.Name, "main") {
+		if strings.Contains(postsubmitConfig.JobBase.Name, "release") {
+			return true, 0, ""
+		} else if strings.Contains(postsubmitConfig.JobBase.Name, "main") {
 			if jobMakeTarget != jc.PostsubmitConformanceMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.PostsubmitConformanceMakeTarget)
 			}


### PR DESCRIPTION
Release postsubmits will [execute a script](https://github.com/aws/eks-distro-prow-jobs/pull/100/files) instead of invoking the `release` target in the Makefile. Hence we can skip the make target check for these jobs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
