### PR TITLE
Fix placement of conditional for make target checks

### DIFF
--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -167,12 +167,13 @@ func PresubmitMakeTargetCheck(jc *JobConstants) presubmitCheck {
 
 func PostsubmitMakeTargetCheck(jc *JobConstants) postsubmitCheck {
 	return postsubmitCheck(func(postsubmitConfig config.Postsubmit, fileContentsString string) (bool, int, string) {
+		if strings.Contains(postsubmitConfig.JobBase.Name, "release") {
+			return true, 0, ""
+		}
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?) .*`).FindStringSubmatch(strings.Join(postsubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
-		if strings.Contains(postsubmitConfig.JobBase.Name, "release") {
-			return true, 0, ""
-		} else if strings.Contains(postsubmitConfig.JobBase.Name, "main") {
+		if strings.Contains(postsubmitConfig.JobBase.Name, "main") {
 			if jobMakeTarget != jc.PostsubmitConformanceMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.PostsubmitConformanceMakeTarget)
 			}


### PR DESCRIPTION
The condition should be checked before retrieving the make target, since it would fail on Prowjobs which don't have make commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
