### PR TITLE
Trigger release job on release change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+.DS_Store

--- a/jobs/aws/eks-distro/release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/release-1-18-postsubmits.yaml
@@ -16,6 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: release-1-18-postsubmit
     always_run: false
+    run_if_changed: "release/1-18/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/release-1-19-postsubmits.yaml
@@ -16,6 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: release-1-19-postsubmit
     always_run: false
+    run_if_changed: "release/1-19/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:


### PR DESCRIPTION
Release job is currently triggering on all postsubmits, it should only run with the release changes.
