### PR TITLE
Add resource limits for big postsubmits jobs

### DIFF
--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -71,6 +71,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -84,6 +88,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -71,6 +71,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -84,6 +88,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -62,7 +62,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
         resources:
-          limits:
+          requests:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
@@ -79,7 +79,7 @@ postsubmits:
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
         resources:
-          limits:
+          requests:
             memory: "4Gi"
             cpu: "1"
         securityContext:

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -61,6 +61,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          limits:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -74,6 +78,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          limits:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -62,7 +62,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
         resources:
-          limits:
+          requests:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
@@ -79,7 +79,7 @@ postsubmits:
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
         resources:
-          limits:
+          requests:
             memory: "4Gi"
             cpu: "1"
         securityContext:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -61,6 +61,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          limits:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -74,6 +78,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          limits:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -63,6 +63,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          limits:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -76,6 +80,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          limits:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
         resources:
-          limits:
+          requests:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
@@ -81,7 +81,7 @@ postsubmits:
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
         resources:
-          limits:
+          requests:
             memory: "4Gi"
             cpu: "1"
         securityContext:

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -63,6 +63,10 @@ postsubmits:
             - -c
             - date +%s > /status/pending
           periodSeconds: 10
+        resources:
+          limits:
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -76,6 +80,10 @@ postsubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          limits:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
         resources:
-          limits:
+          requests:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
@@ -81,7 +81,7 @@ postsubmits:
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
         resources:
-          limits:
+          requests:
             memory: "4Gi"
             cpu: "1"
         securityContext:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding resource limits to our heavier prow jobs after upgrading to bigger instances for our cluster. This is after running into issues with two big jobs being scheduled on one node and running into resource issues. This would ensure that Kubernetes schedules these jobs on nodes that have the capacity as described here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
