### PR TITLE
Modify make check for postsubmits that perform conformance tests

### DIFF
--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -173,7 +173,7 @@ func PostsubmitMakeTargetCheck(jc *JobConstants) postsubmitCheck {
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?) .*`).FindStringSubmatch(strings.Join(postsubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
-		if strings.Contains(postsubmitConfig.JobBase.Name, "main") {
+		if strings.HasPrefix(postsubmitConfig.JobBase.Name, "build-") {
 			if jobMakeTarget != jc.PostsubmitConformanceMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.PostsubmitConformanceMakeTarget)
 			}


### PR DESCRIPTION
This change supports the renaming of `main-1-*-postsubmits` to `build-1-*-postsubmits`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
