### PR TITLE
Fix job trigger regular expression

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: athens-tooling-postsubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/.*"
     cluster: "prow-postsubmits-cluster"
     max_concurrency: 10
     branches:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: athens-tooling-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/gomods/athens/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: helm-chart-tooling-postsubmit
     always_run: false
-    run_if_changed: "helm-charts/*"
+    run_if_changed: "helm-charts/.*"
     cluster: "prow-postsubmits-cluster"
     max_concurrency: 10
     branches:

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: helm-chart-tooling-presubmit
     always_run: false
-    run_if_changed: "helm-charts/*"
+    run_if_changed: "helm-charts/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: release-tooling-presubmit
     always_run: false
-    run_if_changed: "release/*"
+    run_if_changed: "release/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: cni-plugins-presubmit
     always_run: false
-    run_if_changed: "projects/containernetworking/plugins/*"
+    run_if_changed: "projects/containernetworking/plugins/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: main-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^Makefile$|cmd/*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^Makefile$|cmd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false


### PR DESCRIPTION
This fixes the regular expression for job triggers to mean `any file/folder under specified folder`. The configuration we had earlier has always worked since Prow [performs a MatchString check](https://github.com/kubernetes/test-infra/blob/master/prow/config/jobs.go#L303-L311) on the `run_if_changed` regex, and since it finds a matching string (for example, `projects/gomods/athens/`, `helm/`, `release/`, etc), the check passes and the job is triggered. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
