### PR TITLE
Add jobs for Grafana helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .DS_Store
+.idea/

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+postsubmits:
+  aws/eks-distro-build-tooling:
+  - name: grafana-helm-chart-tooling-postsubmit
+    always_run: false
+    run_if_changed: 'helm-charts/scripts/.*|projects/grafana/helm-charts/.*'
+    cluster: "prow-postsubmits-cluster"
+    max_concurrency: 10
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: charts-build-account
+      automountServiceAccountToken: false
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        command:
+        - bash
+        - -c
+        - >
+          make release -C projects/grafana/helm-charts

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro-build-tooling:
+  - name: grafana-helm-chart-tooling-presubmit
+    always_run: false
+    run_if_changed: 'helm-charts/scripts/.*|projects/grafana/helm-charts/.*'
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        command:
+        - bash
+        - -c
+        - >
+          make verify -C projects/grafana/helm-charts
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "512m"
+          limits:
+            memory: "2Gi"
+            cpu: "512m"


### PR DESCRIPTION
We are switching from using managed Grafana, to installing and configuring Grafana using the upstream helm chart. This PR adds presubmit and postsubmit jobs for publishing the charts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
