### PR TITLE
Kubernetes presubmits should use go-runner from public repo

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -34,11 +34,18 @@ presubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:76aeaef060e613e35be46da242ced331e9e9ad5b
+        env:
+        - name: DEVELOPMENT
+          value: "false"
+        - name: RELEASE_BRANCH
+          value: "1-18"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/h1r8a7l5"
         command:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/kubernetes DEVELOPMENT=false RELEASE_BRANCH=1-18
+          make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/1-18/* /logs/artifacts
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -34,11 +34,18 @@ presubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:76aeaef060e613e35be46da242ced331e9e9ad5b
+        env:
+        - name: DEVELOPMENT
+          value: "false"
+        - name: RELEASE_BRANCH
+          value: "1-19"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/h1r8a7l5"
         command:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/kubernetes DEVELOPMENT=false RELEASE_BRANCH=1-19
+          make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/1-19/* /logs/artifacts
           &&


### PR DESCRIPTION
Kubernetes presubmits should use go-runner from public ECR
