### PR TITLE
Add 1.20 postsubmit jobs

### DIFF
--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -12,44 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-presubmits:
+postsubmits:
   aws/eks-distro:
-  - name: kubernetes-1-20-presubmit
+  - name: build-1-20-postsubmit
     always_run: false
-    # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/.*"
-    max_concurrency: 10
-    cluster: "prow-presubmits-cluster"
+    run_if_changed: ".*"
+    max_concurrency: 1
+    cluster: "prow-postsubmits-cluster"
+    branches:
+    - ^main$
     skip_report: false
     decoration_config:
+      timeout: 4h
       gcs_configuration:
-        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
     spec:
-      serviceaccountName: presubmits-build-account
+      serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
         env:
+        - name: TEST_ROLE_ARN
+          value: "arn:aws:iam::125833916567:role/TestBuildRole"
+        - name: ARTIFACT_BUCKET
+          value: "eks-d-postsubmit-artifacts"
+        - name: CONTROL_PLANE_INSTANCE_PROFILE
+          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
+        - name: NODE_INSTANCE_PROFILE
+          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
+        - name: KOPS_STATE_STORE
+          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
         - name: DEVELOPMENT
           value: "false"
         - name: RELEASE_BRANCH
           value: "1-20"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
+        - name: DOCKER_CONFIG
+          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+        - name: REPOSITORY_URI
+          value: "public.ecr.aws/h1r8a7l5"
         command:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/release
+          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
-          make build -C projects/kubernetes/kubernetes
-          &&
-          mv ./projects/kubernetes/kubernetes/_output/1-20/* /logs/artifacts
+          make postsubmit-conformance
           &&
           touch /status/done
         livenessProbe:
@@ -61,11 +75,8 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "26Gi"
-            cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -79,13 +90,10 @@ presubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
-            memory: "1Gi"
-            cpu: "256m"

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,44 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-presubmits:
+postsubmits:
   aws/eks-distro:
-  - name: kubernetes-1-20-presubmit
+  - name: prod-release-1-20-postsubmit
     always_run: false
-    # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/.*"
-    max_concurrency: 10
-    cluster: "prow-presubmits-cluster"
+    run_if_changed: "release/1-20/RELEASE-PUBLIC"
+    max_concurrency: 1
+    cluster: "prow-postsubmits-cluster"
+    branches:
+    - ^main$
     skip_report: false
     decoration_config:
       gcs_configuration:
-        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+      timeout: 4h
     labels:
       image-build: "true"
     spec:
-      serviceaccountName: presubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
         env:
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         - name: DEVELOPMENT
           value: "false"
         - name: RELEASE_BRANCH
           value: "1-20"
+        - name: ARTIFACT_BUCKET
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
+          value: "public.ecr.aws/eks-distro"
         command:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/release
-          &&
-          make build -C projects/kubernetes/kubernetes
-          &&
-          mv ./projects/kubernetes/kubernetes/_output/1-20/* /logs/artifacts
+          ./release/prow-release.sh
           &&
           touch /status/done
         livenessProbe:
@@ -61,11 +65,8 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "26Gi"
-            cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:master-rootless
         command:
@@ -79,13 +80,10 @@ presubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
-            memory: "1Gi"
-            cpu: "256m"


### PR DESCRIPTION
Two things here:

* Added call to build kubernetes/release to kubernetes presubmit so that go-runner will always be there (maybe)
* Added other 1.20 postsubmit jobs, the key one is the build one so we get go-runner the next time around
