### PR TITLE
Disable 1.20 presubmit for now

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -45,9 +45,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/release
-          &&
-          make build -C projects/kubernetes/kubernetes
+          make build -C projects/kubernetes/kubernetes || true
           &&
           mv ./projects/kubernetes/kubernetes/_output/1-20/* /logs/artifacts
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes/kubernetes || true
+          make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/1-20/* /logs/artifacts
           &&


### PR DESCRIPTION
We need to run the postsubmit build before the presubmit will pass