### PR TITLE
Adding release versioned presubmit jobs

### DIFF
--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   aws/eks-distro:
-  - name: aws-iam-authenticator-presubmit
+  - name: aws-iam-authenticator-1-18-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
@@ -33,6 +33,9 @@ presubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-18"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -1,0 +1,77 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: aws-iam-authenticator-1-19-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-19"
+        command:
+        - bash
+        - -c
+        - >
+          make build -C projects/kubernetes-sigs/aws-iam-authenticator DEVELOPMENT=false
+          &&
+          mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
+          limits:
+            memory: "2Gi"
+            cpu: "1024m"
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   aws/eks-distro:
-  - name: coredns-presubmit
+  - name: coredns-1-18-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/coredns/coredns/.*"
     max_concurrency: 10
@@ -33,6 +33,9 @@ presubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-18"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -14,9 +14,9 @@
 
 presubmits:
   aws/eks-distro:
-  - name: metrics-server-presubmit
+  - name: coredns-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -33,11 +33,14 @@ presubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-19"
         command:
-        - sh
+        - bash
         - -c
         - >
-          make build -C projects/kubernetes-sigs/metrics-server DEVELOPMENT=false
+          make build -C projects/coredns/coredns DEVELOPMENT=false
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -1,0 +1,75 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: metrics-server-1-18-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/metrics-server/.*"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-18"
+        command:
+        - sh
+        - -c
+        - >
+          make build -C projects/kubernetes-sigs/metrics-server DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1024m"
+          limits:
+            memory: "4Gi"
+            cpu: "1024m"
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -1,0 +1,75 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: metrics-server-1-19-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|projects/kubernetes-sigs/metrics-server/.*"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:199e941a6e1499870717e8b05178072e0b69b0fe
+        env:
+        - name: RELEASE_BRANCH
+          value: "1-19"
+        command:
+        - sh
+        - -c
+        - >
+          make build -C projects/kubernetes-sigs/metrics-server DEVELOPMENT=false
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1024m"
+          limits:
+            memory: "4Gi"
+            cpu: "1024m"
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000


### PR DESCRIPTION
Modifying presubmit jobs for coredns, aws-iam-auth and metrics-server to run for every release version based on RELEASE_BRANCH env variable.