### PR TITLE
add attribution-files-periodic to update attribution.txt files 

### DIFF
--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -1,0 +1,69 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+periodics:
+- name: attribution-files-periodic
+  # Runs every weekday (M-F) at 10am PST
+  cron: "0 18 * * 1-5"
+  cluster: "prow-postsubmits-cluster"
+  decoration_config:
+    gcs_configuration:
+      bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+      path_strategy: explicit
+    s3_credentials_secret: s3-credentials
+  extra_refs:
+  - org: eks-distro-pr-bot
+    repo: eks-distro
+    base_ref: main
+  spec:
+    serviceaccountName: periodics-build-account
+    automountServiceAccountToken: false
+    containers:
+    - name: build-container
+      image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e98fcde28fd0d85949047083e24c1daf6f961237
+      command:
+      - bash
+      - -c
+      - >
+        make update-attribution-files -C eks-distro
+      env:
+      - name: REPO_OWNER
+        value: "aws"
+      volumeMounts:
+      - name: ssh-auth
+        mountPath: /secrets/ssh-secrets
+        readOnly: true
+      - name: github-auth
+        mountPath: /secrets/github-secrets
+        readOnly: true
+      livenessProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - date +%s > /status/pending
+        periodSeconds: 10
+      resources:
+        requests:
+          memory: "16Gi"
+          cpu: "4"
+    volumes:
+    - name: ssh-auth
+      secret:
+        defaultMode: 256
+        secretName: pr-bot-ssh-secret
+    - name: github-auth
+      secret:
+        defaultMode: 256
+        secretName: pr-bot-github-token

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -15,7 +15,7 @@
 periodics:
 - name: attribution-files-periodic
   # Runs every day at 2pm PST
-  cron: "0 21 * * *"
+  cron: "*/15 * * * *"
   cluster: "prow-postsubmits-cluster"
   decoration_config:
     gcs_configuration:
@@ -36,7 +36,7 @@ periodics:
       - bash
       - -c
       - >
-        make update-attribution-files -C eks-distro
+        make update-attribution-files
       env:
       - name: REPO_OWNER
         value: "aws"

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -14,8 +14,8 @@
 
 periodics:
 - name: attribution-files-periodic
-  # Runs every weekday (M-F) at 10am PST
-  cron: "0 18 * * 1-5"
+  # Runs every day at 2pm PST
+  cron: "0 21 * * *"
   cluster: "prow-postsubmits-cluster"
   decoration_config:
     gcs_configuration:

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -47,13 +47,6 @@ periodics:
       - name: github-auth
         mountPath: /secrets/github-secrets
         readOnly: true
-      livenessProbe:
-        exec:
-          command:
-          - bash
-          - -c
-          - date +%s > /status/pending
-        periodSeconds: 10
       resources:
         requests:
           memory: "16Gi"


### PR DESCRIPTION
https://github.com/aws/eks-distro/pull/242 adds attribution generation to eks-distro to allow us to keep these attribution.txt files up to date.  Generating the files requires a bit of setup and to avoid putting this on the developers contributing to eks-distro we decided to introduce a periodic to generate files across all projects and check in any changes.  Checking in changes to attribution files by themselves also gives us a clear audit trail since they will only ever be changed in bot commits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

