### PR TITLE
sync repo from aws org instead of fork

### DIFF
--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   extra_refs:
-  - org: eks-distro-pr-bot
+  - org: aws
     repo: eks-distro
     base_ref: main
   spec:


### PR DESCRIPTION
Instead of pulling down the bot's fork, pull down from the aws org to make sure its always up to date.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

