### PR TITLE
tighten up run_if_changed for kubernetes to only build changed version

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
   - name: kubernetes-1-18-presubmit
     always_run: false
     # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/.*"
+    run_if_changed: "projects/kubernetes/kubernetes/(build|docker|Makefile|1-18)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
   - name: kubernetes-1-19-presubmit
     always_run: false
     # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/.*"
+    run_if_changed: "projects/kubernetes/kubernetes/(build|docker|Makefile|1-19)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
   - name: kubernetes-1-20-presubmit
     always_run: false
     # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/.*"
+    run_if_changed: "projects/kubernetes/kubernetes/(build|docker|Makefile|1-20)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false


### PR DESCRIPTION
It it worth tightening up the regex to avoid building all versions of kubernetes when any change?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

