### PR TITLE
only run kubernetes unit tests when neccessary

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits-tests.yaml
@@ -1,0 +1,50 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: kubernetes-1-18-presubmit-tests
+    always_run: false
+    run_if_changed: "projects/kubernetes/kubernetes/1-18/(GIT_TAG|patches)"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:b729ea295aec9b2d271179b004ba2624cb950969
+        env:
+        - name: DEVELOPMENT
+          value: "false"
+        - name: RELEASE_BRANCH
+          value: "1-18"
+        command:
+        - bash
+        - -c
+        - >
+          make test -C projects/kubernetes/kubernetes
+        resources:
+          requests:
+            memory: "26Gi"
+            cpu: "3584m"
+          limits:
+            memory: "26Gi"
+            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits-tests.yaml
@@ -1,0 +1,50 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: kubernetes-1-19-presubmit-tests
+    always_run: false
+    run_if_changed: "projects/kubernetes/kubernetes/1-19/(GIT_TAG|patches)"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:b729ea295aec9b2d271179b004ba2624cb950969
+        env:
+        - name: DEVELOPMENT
+          value: "false"
+        - name: RELEASE_BRANCH
+          value: "1-19"
+        command:
+        - bash
+        - -c
+        - >
+          make test -C projects/kubernetes/kubernetes
+        resources:
+          requests:
+            memory: "26Gi"
+            cpu: "3584m"
+          limits:
+            memory: "26Gi"
+            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits-tests.yaml
@@ -1,0 +1,50 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-distro:
+  - name: kubernetes-1-20-presubmit-tests
+    always_run: false
+    run_if_changed: "projects/kubernetes/kubernetes/1-20/(GIT_TAG|patches)"
+    max_concurrency: 10
+    cluster: "prow-presubmits-cluster"
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:b729ea295aec9b2d271179b004ba2624cb950969
+        env:
+        - name: DEVELOPMENT
+          value: "false"
+        - name: RELEASE_BRANCH
+          value: "1-20"
+        command:
+        - bash
+        - -c
+        - >
+          make test -C projects/kubernetes/kubernetes
+        resources:
+          requests:
+            memory: "26Gi"
+            cpu: "3584m"
+          limits:
+            memory: "26Gi"
+            cpu: "3584m"

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -39,6 +39,7 @@ type JobConstants struct {
 	HelmMakeTarget                  string
 	ReleaseToolingMakeTarget        string
 	PostsubmitConformanceMakeTarget string
+	TestsMakeTarget                 string
 }
 
 type UnmarshaledJobConfig struct {
@@ -64,6 +65,7 @@ func (jc *JobConstants) Init(jobType string) {
 		jc.DefaultMakeTarget = "build"
 		jc.HelmMakeTarget = "verify"
 		jc.ReleaseToolingMakeTarget = "test"
+		jc.TestsMakeTarget = "test"
 	}
 }
 
@@ -158,6 +160,10 @@ func PresubmitMakeTargetCheck(jc *JobConstants) presubmitCheck {
 			if jobMakeTarget != jc.ReleaseToolingMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.ReleaseToolingMakeTarget)
 			}
+		} else if strings.Contains(presubmitConfig.JobBase.Name, "tests") {
+			if jobMakeTarget != jc.TestsMakeTarget {
+				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.TestsMakeTarget)
+			}
 		} else if jobMakeTarget != jc.DefaultMakeTarget {
 			return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.DefaultMakeTarget)
 		}
@@ -170,9 +176,9 @@ func PostsubmitMakeTargetCheck(jc *JobConstants) postsubmitCheck {
 		if strings.Contains(postsubmitConfig.JobBase.Name, "release") {
 			return true, 0, ""
 		}
-        if strings.Contains(postsubmitConfig.JobBase.Name, "announcement") {
-            return true, 0, ""
-        }
+		if strings.Contains(postsubmitConfig.JobBase.Name, "announcement") {
+			return true, 0, ""
+		}
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?) .*`).FindStringSubmatch(strings.Join(postsubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")


### PR DESCRIPTION
We really only need to run the unit tests when changing the kubernetes version (GIT_TAG) or modifying/adding to the patches.

Will need to make an update to eks-distro to remove `test` from the [build](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/kubernetes/Makefile#L107) target 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
