### PR TITLE
Target environment release file

### DIFF
--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: dev-release-1-18-postsubmit
     always_run: false
-    run_if_changed: "release/1-18/RELEASE"
+    run_if_changed: "release/1-18/development/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: dev-release-1-19-postsubmit
     always_run: false
-    run_if_changed: "release/1-19/RELEASE"
+    run_if_changed: "release/1-19/development/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: dev-release-1-20-postsubmit
     always_run: false
-    run_if_changed: "release/1-20/RELEASE"
+    run_if_changed: "release/1-20/development/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: prod-release-1-18-postsubmit
     always_run: false
-    run_if_changed: "release/1-18/RELEASE-PUBLIC"
+    run_if_changed: "release/1-18/production/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -45,6 +45,8 @@ postsubmits:
           value: "false"
         - name: RELEASE_BRANCH
           value: "1-18"
+        - name: RELEASE_ENVIRONMENT
+          value: "production"
         - name: ARTIFACT_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: IMAGE_REPO

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -45,6 +45,8 @@ postsubmits:
           value: "false"
         - name: RELEASE_BRANCH
           value: "1-19"
+        - name: RELEASE_ENVIRONMENT
+          value: "production"
         - name: ARTIFACT_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: IMAGE_REPO

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: prod-release-1-19-postsubmit
     always_run: false
-    run_if_changed: "release/1-19/RELEASE-PUBLIC"
+    run_if_changed: "release/1-19/production/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro:
   - name: prod-release-1-20-postsubmit
     always_run: false
-    run_if_changed: "release/1-20/RELEASE-PUBLIC"
+    run_if_changed: "release/1-20/production/RELEASE"
     max_concurrency: 1
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -45,6 +45,8 @@ postsubmits:
           value: "false"
         - name: RELEASE_BRANCH
           value: "1-20"
+        - name: RELEASE_ENVIRONMENT
+          value: "production"
         - name: ARTIFACT_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: IMAGE_REPO


### PR DESCRIPTION
Use two independent RELEASE files so that development and production builds can be triggered complete independently.
