### PR TITLE
Configure eks-distro-base and builder-base images to be pushed to public ECR repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/eks-distro-prow-jobs
 
-go 1.13
+go 1.16
 
-replace k8s.io/client-go => k8s.io/client-go v0.20.1
+replace k8s.io/client-go => k8s.io/client-go v0.20.2

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -42,6 +42,9 @@ postsubmits:
       containers:
       - name: build-container
         image: 137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:2
+        env:
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/h1r8a7l5"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -40,6 +40,9 @@ periodics:
     containers:
     - name: build-container
       image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      env:
+      - name: IMAGE_REPO
+        value: "public.ecr.aws/h1r8a7l5"
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -42,6 +42,9 @@ postsubmits:
       containers:
       - name: build-container
         image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        env:
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/h1r8a7l5"
         command:
         - bash
         - -c


### PR DESCRIPTION
With this change, the builder-base and eks-distro-base images will get pushed to the corresponding public ECR repos instead of private ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
