### PR TITLE
Add module requirements explicitly for Go 1.16

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -35,6 +35,8 @@ presubmits:
         - bash
         - -c
         - >
+          go mod tidy
+          &&
           go vet scripts/lint_prowjobs/main.go
           &&
           go run scripts/lint_prowjobs/main.go


### PR DESCRIPTION
According to the [module changes](https://golang.org/doc/go1.16#go-command) in Go 1.16, build and run commands do not modify `go.mod` and `go.sum` by default and report an error if these files need to be updated. Module requirements may be adjusted using `go mod tidy`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
