### PR TITLE
Add public ECR endpoint to credential helper config

### DIFF
--- a/config/docker-ecr-config.json
+++ b/config/docker-ecr-config.json
@@ -3,6 +3,7 @@
         "316434458148.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "862665599504.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "137112412989.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
-        "520703868821.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
+        "520703868821.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
+        "public.ecr.aws": "ecr-login"
     }
 }


### PR DESCRIPTION
Need to add this endpoint so that amazon ECR credential helper can authenticate with public ECR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
