### PR TITLE
Update Prowjobs to use builder-base from public ECR

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
@@ -32,7 +32,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -39,7 +39,7 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
       env:
       - name: IMAGE_REPO
         value: "public.ecr.aws/h1r8a7l5"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
@@ -34,7 +34,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/announcement-postsubmits.yaml
+++ b/jobs/aws/eks-distro/announcement-postsubmits.yaml
@@ -32,7 +32,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-18"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-19"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-20"

--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+      - image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-18"

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-19"

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-20"

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: AWS_REGION
           value: "us-east-1"

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: AWS_REGION
           value: "us-east-1"

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: AWS_REGION
           value: "us-east-1"

--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -32,7 +32,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/docs-presubmit.yaml
+++ b/jobs/aws/eks-distro/docs-presubmit.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits-tests.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits-tests.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits-tests.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits-tests.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: DEVELOPMENT
           value: "false"

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-18"

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-19"

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: RELEASE_BRANCH
           value: "1-20"

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:4ae475cf720cb0067bb87ffa056fa499440e7ca2
+        image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"


### PR DESCRIPTION
Modified Prowjobs to consume builder-base images from ECR-public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
