### PR TITLE
Configure base image Prowjobs to push to eks-distro-build-tooling ECR public registry

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -44,7 +44,9 @@ postsubmits:
         image: 137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:2
         env:
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -42,7 +42,9 @@ periodics:
       image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
       env:
       - name: IMAGE_REPO
-        value: "public.ecr.aws/h1r8a7l5"
+        value: "public.ecr.aws/eks-distro-build-tooling"
+      - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -44,7 +44,9 @@ postsubmits:
         image: public.ecr.aws/h1r8a7l5/eks-distro/builder:143f709aa86128f5f990c928941d54f1db572468
         env:
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         command:
         - bash
         - -c


### PR DESCRIPTION
We want to push the builder-base and eks-distro-base images to the `eks-distro-build-tooling` public registry in a verified account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
