### PR TITLE
Trigger base image jobs when ECR setup script changes

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: builder-base-tooling-postsubmit
     always_run: false
-    run_if_changed: "builder-base/.*|generate-attribution/.*"
+    run_if_changed: "builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: builder-base-tooling-presubmit
     always_run: false
-    run_if_changed: "builder-base/.*|generate-attribution/.*"
+    run_if_changed: "builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-tooling-postsubmit
     always_run: false
-    run_if_changed: "eks-distro-base/.*"
+    run_if_changed: "eks-distro-base/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
     cluster: "prow-postsubmits-cluster"
     branches:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-tooling-presubmit
     always_run: false
-    run_if_changed: "eks-distro-base/.*"
+    run_if_changed: "eks-distro-base/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     extra_refs:


### PR DESCRIPTION
The `scripts` folder has a script to setup pushes of base images to ECR public, so changes to this script might change the way we push to public ECR. So we should trigger the base image builds when we modify it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
