### PR TITLE
Set default region as env var in prowjobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -47,6 +47,8 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -45,6 +45,8 @@ periodics:
         value: "public.ecr.aws/eks-distro-build-tooling"
       - name: ECR_PUBLIC_PUSH_ROLE_ARN
         value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+      - name: AWS_REGION
+        value: "us-east-1"
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -47,6 +47,8 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         command:
         - bash
         - -c


### PR DESCRIPTION
Setting default region to us-east-1 to be used in config file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
