### PR TITLE
Run ECR setup script before invoking make

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -55,6 +55,8 @@ postsubmits:
         - >
           ./builder-base/install.sh
           &&
+          ./scripts/setup_public_ecr_push.sh
+          &&
           make release -C builder-base DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -51,6 +51,8 @@ periodics:
       - bash
       - -c
       - >
+        ./scripts/setup_public_ecr_push.sh
+        &&
         make update -C eks-distro-base
         &&
         touch /status/done;

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -55,6 +55,8 @@ postsubmits:
         - >
           export DATE_EPOCH=$(date "+%F-%s")
           &&
+          ./scripts/setup_public_ecr_push.sh
+          &&
           make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=${DATE_EPOCH}
           &&
           touch /status/done


### PR DESCRIPTION
Moving the ECR setup script to the prowjob definition to align with eks-d prod-release jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
