### PR TITLE
Remove DEVELOPMENT var from build-tooling jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make release -C projects/aws/amazon-eks-pod-identity-webhook DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          make release -C projects/aws/amazon-eks-pod-identity-webhook IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/aws/amazon-eks-pod-identity-webhook DEVELOPMENT=false
+          make build -C projects/aws/amazon-eks-pod-identity-webhook
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -57,7 +57,7 @@ postsubmits:
           &&
           source scripts/setup_public_ecr_push.sh
           &&
-          make release -C builder-base DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done
         volumeMounts:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -46,7 +46,7 @@ presubmits:
         - >
           ./builder-base/install.sh
           &&
-          make build -C builder-base DEVELOPMENT=false
+          make build -C builder-base
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -57,7 +57,7 @@ postsubmits:
           &&
           source scripts/setup_public_ecr_push.sh
           &&
-          make release -C eks-distro-base DEVELOPMENT=false IMAGE_TAG=${DATE_EPOCH}
+          make release -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}
           &&
           touch /status/done
         volumeMounts:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C eks-distro-base DEVELOPMENT=false
+          make build -C eks-distro-base
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make release -C projects/infinityworks/github-exporter DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          make release -C projects/infinityworks/github-exporter IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/infinityworks/github-exporter DEVELOPMENT=false
+          make build -C projects/infinityworks/github-exporter
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
         - bash
         - -c
         - >
-          make release -C projects/prometheus/alertmanager DEVELOPMENT=false IMAGE_TAG=$PULL_BASE_SHA
+          make release -C projects/prometheus/alertmanager IMAGE_TAG=$PULL_BASE_SHA
           &&
           touch /status/done
         livenessProbe:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/prometheus/alertmanager DEVELOPMENT=false
+          make build -C projects/prometheus/alertmanager
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
/hold
We don't need this variable here anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
