### PR TITLE
Replace 1-20 references in 1-21 jobs

### DIFF
--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -14,7 +14,7 @@
 
 postsubmits:
   aws/eks-distro:
-  - name: build-1-20-postsubmit
+  - name: build-1-21-postsubmit
     always_run: false
     run_if_changed: ".*"
     max_concurrency: 1

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -14,10 +14,10 @@
 
 presubmits:
   aws/eks-distro:
-  - name: kubernetes-1-20-presubmit
+  - name: kubernetes-1-21-presubmit
     always_run: false
     # TODO: tweak to only run if Makefile, build, release branch files change
-    run_if_changed: "projects/kubernetes/kubernetes/(build|docker|Makefile|1-20)"
+    run_if_changed: "projects/kubernetes/kubernetes/(build|docker|Makefile|1-21)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -45,7 +45,7 @@ presubmits:
         - >
           make build -C projects/kubernetes/kubernetes
           &&
-          mv ./projects/kubernetes/kubernetes/_output/1-20/* /logs/artifacts
+          mv ./projects/kubernetes/kubernetes/_output/1-21/* /logs/artifacts
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
* Replace `1-20` references with `1-21`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
