### PR TITLE
Fix version conflict errors for prowjobs-lint-presubmit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,15 @@ module github.com/aws/eks-distro-prow-jobs
 
 go 1.16
 
-replace k8s.io/client-go => k8s.io/client-go v0.20.2
+replace (
+	k8s.io/api => k8s.io/api v0.20.2
+	k8s.io/apimachinery => k8s.io/apimachinery v0.20.2
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.1
+	k8s.io/client-go => k8s.io/client-go v0.20.2
+	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.8.3-0.20210301154926-12660d4f2255
+)
+
+require (
+	k8s.io/test-infra v0.0.0-20210608224924-94f3f2343d63
+	sigs.k8s.io/yaml v1.2.0
+)


### PR DESCRIPTION
*Description of changes:*
Fixes broken [prowjobs-lint-presubmit](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-distro-prow-jobs/184/prowjobs-lint-presubmit/1402413575649103872#2:build-log.txt%3A154)...hopefully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
