### PR TITLE
add arm based kops cluster post submit

### DIFF
--- a/jobs/aws/eks-distro/build-1-21-arm64-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-arm64-postsubmits.yaml
@@ -1,0 +1,99 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+postsubmits:
+  aws/eks-distro:
+  - name: build-1-21-arm64-postsubmit
+    always_run: false
+    run_if_changed: ".*"
+    max_concurrency: 1
+    cluster: "prow-postsubmits-cluster"
+    branches:
+    - ^main$
+    skip_report: false
+    decoration_config:
+      timeout: 6h
+      gcs_configuration:
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:88b721da50cc2dd56446af65b3a43b8c83b7dcd4
+        env:
+        - name: TEST_ROLE_ARN
+          value: "arn:aws:iam::125833916567:role/TestBuildRole"
+        - name: ARTIFACT_BUCKET
+          value: "eks-d-postsubmit-artifacts"
+        - name: CONTROL_PLANE_INSTANCE_PROFILE
+          value: "arn:aws:iam::125833916567:instance-profile/Kops121ControlPlaneBuildRole"
+        - name: NODE_INSTANCE_PROFILE
+          value: "arn:aws:iam::125833916567:instance-profile/Kops121NodesBuildRole"
+        - name: KOPS_STATE_STORE
+          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+        - name: RELEASE_BRANCH
+          value: "1-21"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/h1r8a7l5"
+        - name: DOCKER_CONFIG
+          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+        - name: NODE_INSTANCE_TYPE
+          value: t4g.medium
+        - name: NODE_ARCHITECTURE
+          value: arm64
+        command:
+        - bash
+        - -c
+        - >
+          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          &&
+          make postsubmit-conformance
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
+      - name: buildkitd
+        image: moby/buildkit:master-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000


### PR DESCRIPTION
I would add these for all versions, but the upstream conformance images for versions less than 1.21 arent really arm64 so they wont work.  This is a good start though.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
