### PR TITLE
Use latest stable release of buildkitd sidecar image

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "2Gi"
             cpu: "512m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -79,7 +79,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1536m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -75,7 +75,7 @@ periodics:
           - date +%s > /status/pending
         periodSeconds: 10
     - name: buildkitd
-      image: moby/buildkit:master-rootless
+      image: moby/buildkit:v0.9.0-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -77,7 +77,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
@@ -50,7 +50,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-18-minimal-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-minimal-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-19-minimal-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-minimal-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-20-minimal-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-minimal-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-21-minimal-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-minimal-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-18-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-release-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-19-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-release-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-20-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-release-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-21-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-release-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:master-rootless
+        image: moby/buildkit:v0.9.0-rootless
         command:
         - sh
         args:


### PR DESCRIPTION
Master head commit of https://github.com/moby/buildkit has some breaking changes, so best to use a tagged version that matches with the buildctl version we use.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
