### PR TITLE
Rename release tooling presubmit to avoid conflicts

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-release-tooling-presubmits.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   aws/eks-distro-build-tooling:
-  - name: release-tooling-presubmit
+  - name: eks-distro-release-tooling-presubmit
     always_run: false
     run_if_changed: "release/.*"
     cluster: "prow-presubmits-cluster"


### PR DESCRIPTION
Rename job to clarify purpose and avoid conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
