### PR TITLE
Clone eks-anywhere repos to support automation

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -23,10 +23,10 @@ postsubmits:
     - ^main$
     extra_refs:
     - org: eks-distro-pr-bot
-      repo: eks-distro-build-tooling
+      repo: eks-distro-prow-jobs
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-distro-prow-jobs
+      repo: eks-anywhere-prow-jobs
       base_ref: main
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -21,10 +21,10 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     extra_refs:
     - org: eks-distro-pr-bot
-      repo: eks-distro-build-tooling
+      repo: eks-distro-prow-jobs
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-distro-prow-jobs
+      repo: eks-anywhere-prow-jobs
       base_ref: main
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -34,6 +34,9 @@ periodics:
   - org: eks-distro-pr-bot
     repo: eks-distro
     base_ref: main
+  - org: eks-distro-pr-bot
+    repo: eks-anywhere-build-tooling
+    base_ref: main
   spec:
     serviceaccountName: periodics-build-account
     automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -28,6 +28,9 @@ postsubmits:
     - org: eks-distro-pr-bot
       repo: eks-distro
       base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-anywhere-build-tooling
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -26,6 +26,9 @@ presubmits:
     - org: eks-distro-pr-bot
       repo: eks-distro
       base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-anywhere-build-tooling
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:


### PR DESCRIPTION
Tag update automation needs to be handled for EKS-A build tooling and prowjob repos as well.
/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
