### PR TITLE
Use public ECR AL2 image as Prowjobs runtime

### DIFF
--- a/config/docker-ecr-config.json
+++ b/config/docker-ecr-config.json
@@ -2,7 +2,6 @@
     "credHelpers": {
         "316434458148.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "862665599504.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
-        "137112412989.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "520703868821.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
         "public.ecr.aws": "ecr-login"
     }

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:2
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
         env:
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro-build-tooling"

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: 137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:2
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
         command:
         - bash
         - -c


### PR DESCRIPTION
Changing builder-base Prowjobs to use AL2 from public ECR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
