### PR TITLE
eks-distro-pre: add docker registry to support pushing to local reg

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -84,8 +84,24 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "1Gi"
+            cpu: "256m"
           limits:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "1Gi"
+            cpu: "256m"
+      - name: registry
+        image: registry:2
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "256m"
+          limits:
+            memory: "1Gi"
+            cpu: "256m"


### PR DESCRIPTION
To support building minimal variants we need a local registry to push to.  This shouldnt break existing builds and will give me a way to test out in my branch where I will hardcode the image_repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
