### PR TITLE
eks-distro-base: fix presubmit registry sidecar

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -37,19 +37,25 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      local-registry: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9d8b18871b951e9c92f5db2949efdb14ef7ef1e9
+        env:
+        - name: IMAGE_REPO
+          value: "localhost:5000"
         command:
         - bash
         - -c
         - >
-          make build -C eks-distro-base
+          export DATE_EPOCH=$(date "+%F-%s")
           &&
-          make create-pr -C eks-distro-base
+          make build -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}
+          &&
+          make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}
           &&
           touch /status/done
         livenessProbe:
@@ -91,6 +97,10 @@ presubmits:
             cpu: "256m"
       - name: registry
         image: registry:2
+        command:
+        - sh
+        args:
+        - /script/registry-entrypoint.sh
         livenessProbe:
           exec:
             command:
@@ -98,6 +108,13 @@ presubmits:
             - -c
             - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
           periodSeconds: 15
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 3
         resources:
           requests:
             memory: "1Gi"

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -14,6 +14,19 @@
 
 presets:
 - labels:
+    local-registry: "true"
+  volumeMounts:
+  - name: registry-entrypoint
+    readOnly: false
+    mountPath: /script
+  volumes:
+  - name: registry-entrypoint
+    configMap:
+      name: registry-entrypoint
+      items:
+      - key: registry-entrypoint.sh
+        path: registry-entrypoint.sh
+- labels:
     image-build: "true"
   env:
   - name: AWS_SDK_LOAD_CONFIG

--- a/scripts/registry-entrypoint.sh
+++ b/scripts/registry-entrypoint.sh
@@ -1,0 +1,24 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run registry in background mode to be able to poll
+# for the done status file and kill process after
+
+registry serve /etc/docker/registry/config.yml & 
+pid=$!
+while [ ! -f /status/done ]
+do
+  sleep 5
+done
+kill $pid


### PR DESCRIPTION
Add proper readiness/liveness probes.  Fix command + args.  Hardcode image_repo to point to local registry

/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
