### PR TITLE
kubernetes-presubmit: only push release images to local registry

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -39,17 +39,13 @@ presubmits:
           value: "1-18"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: IMAGE_OUTPUT_TYPE
-          value: image
-        - name: IMAGE_OUTPUT
-          value: push=true
         command:
         - bash
         - -c
         - >
           build/lib/buildkit_check.sh
           &&
-          make build clean -C projects/kubernetes/release
+          make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C projects/kubernetes/kubernetes
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -39,17 +39,13 @@ presubmits:
           value: "1-19"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: IMAGE_OUTPUT_TYPE
-          value: image
-        - name: IMAGE_OUTPUT
-          value: push=true
         command:
         - bash
         - -c
         - >
           build/lib/buildkit_check.sh
           &&
-          make build clean -C projects/kubernetes/release
+          make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C projects/kubernetes/kubernetes
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -39,17 +39,13 @@ presubmits:
           value: "1-20"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: IMAGE_OUTPUT_TYPE
-          value: image
-        - name: IMAGE_OUTPUT
-          value: push=true
         command:
         - bash
         - -c
         - >
           build/lib/buildkit_check.sh
           &&
-          make build clean -C projects/kubernetes/release
+          make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C projects/kubernetes/kubernetes
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -39,17 +39,13 @@ presubmits:
           value: "1-21"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: IMAGE_OUTPUT_TYPE
-          value: image
-        - name: IMAGE_OUTPUT
-          value: push=true
         command:
         - bash
         - -c
         - >
           build/lib/buildkit_check.sh
           &&
-          make build clean -C projects/kubernetes/release
+          make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C projects/kubernetes/kubernetes
           &&


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To validate the s3 artifacts in the presubmit we need to build tars for the images instead of pushing to the registry.  This overrides the image output only for the release project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
