### PR TITLE
Run all tests only if build-lib at root changed

### DIFF
--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-1-18-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-1-20-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: aws-iam-authenticator-1-21-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/aws-iam-authenticator/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: cni-plugins-presubmit
     always_run: false
-    run_if_changed: "build/lib/.*|Makefile.common|projects/containernetworking/plugins/.*"
+    run_if_changed: "^build/lib/.*|Makefile.common|projects/containernetworking/plugins/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: coredns-1-18-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: coredns-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: coredns-1-20-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: coredns-1-21-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/coredns/coredns/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: etcd-1-18-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: etcd-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: etcd-1-20-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: etcd-1-21-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/etcd-io/etcd/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-attacher-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/external-attacher/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/external-attacher/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-provisioner-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/external-provisioner/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/external-provisioner/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-resizer-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/external-resizer/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/external-resizer/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: external-snapshotter-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/external-snapshotter/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/external-snapshotter/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-18-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-18)"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-18)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-18-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-release-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-18-release-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-19)"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-19)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-19-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-release-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-19-release-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-20-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-20)"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-20)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-20-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-release-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-20-release-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-21-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-21)"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/kubernetes/(build|docker|Makefile|1-21)"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/kubernetes-1-21-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-release-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: kubernetes-1-21-release-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes/release/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: livenessprobe-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/livenessprobe/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/livenessprobe/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: metrics-server-1-18-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: metrics-server-1-19-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: metrics-server-1-20-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: metrics-server-1-21-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-sigs/metrics-server/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-distro:
   - name: node-driver-registrar-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|build/lib/.*|Makefile.common|projects/kubernetes-csi/node-driver-registrar/.*"
+    run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Makefile.common|projects/kubernetes-csi/node-driver-registrar/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false


### PR DESCRIPTION
There is an internal `build/lib` under Kubernetes project and the current run_if_changed matches that too, since we don't specify the regex anchor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
