### PR TITLE
Add eks-anywhere repos to Prowjobs to update base image

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -37,6 +37,9 @@ periodics:
   - org: eks-distro-pr-bot
     repo: eks-anywhere-build-tooling
     base_ref: main
+  - org: eks-distro-pr-bot
+    repo: eks-anywhere
+    base_ref: main
   spec:
     serviceaccountName: periodics-build-account
     automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -31,6 +31,9 @@ postsubmits:
     - org: eks-distro-pr-bot
       repo: eks-anywhere-build-tooling
       base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-anywhere
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -29,6 +29,9 @@ presubmits:
     - org: eks-distro-pr-bot
       repo: eks-anywhere-build-tooling
       base_ref: main
+    - org: eks-distro-pr-bot
+      repo: eks-anywhere
+      base_ref: main
     skip_report: false
     decoration_config:
       gcs_configuration:


### PR DESCRIPTION
Clone the EKS Anywhere repo in the Prowjobs to include it in tag update PR automation workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
