### PR TITLE
coredns and etcd skip arm validation for oci in presubmit

### DIFF
--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -36,6 +36,8 @@ presubmits:
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         command:
         - bash
         - -c


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Working on sync-ing common make file changes from eks-a to eks-d, [here](https://github.com/aws/eks-distro/pull/631). These two projects build local oci tars for both amd64 and arm64 but in presubmit we need to need to ignore the missing arm64 builds since we do not build arm images on presubmit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
