### PR TITLE
Modify lint presubmit to generate prowjobs before linting

### DIFF
--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -35,11 +35,9 @@ presubmits:
         - bash
         - -c
         - >
-          go mod tidy
+          make prowjobs -C templater
           &&
-          go vet scripts/lint_prowjobs/main.go
-          &&
-          go run scripts/lint_prowjobs/main.go
+          make lint -C linter
         resources:
           requests:
             memory: "8Gi"

--- a/linter/Makefile
+++ b/linter/Makefile
@@ -1,0 +1,31 @@
+ifndef PULL_BASE_SHA
+export PULL_BASE_SHA=$(shell git show -s --format=%H upstream/main)
+endif
+ifndef PULL_PULL_SHA
+export PULL_PULL_SHA=$(shell git show -s --format=%H)
+endif
+
+BIN_DIR := bin
+
+.PHONY: all
+all: build lint
+
+.PHONY: build
+build:  ## Build linter
+build: fmt vet
+	go build -o ./$(BIN_DIR)/prow-linter github.com/aws/eks-distro-prow-jobs/linter
+
+fmt: ## Run go fmt against code.
+	go fmt ./...
+
+vet: ## Run go vet against code.
+	go vet ./...
+
+.PHONY: lint
+lint: ## Run linter
+lint: build
+	./$(BIN_DIR)/prow-linter
+
+.PHONY: help
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[%\/0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/linter/main.go
+++ b/linter/main.go
@@ -162,7 +162,7 @@ func PresubmitMakeTargetCheck(jc *JobConstants) presubmitCheck {
 			if jobMakeTarget != jc.ReleaseToolingMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.ReleaseToolingMakeTarget)
 			}
-		} else if strings.Contains(presubmitConfig.JobBase.Name, "tests") {
+		} else if strings.Contains(presubmitConfig.JobBase.Name, "test") {
 			if jobMakeTarget != jc.TestsMakeTarget {
 				return false, makeCommandLineNo, fmt.Sprintf(`Invalid make target, please use the "%s" target`, jc.TestsMakeTarget)
 			}
@@ -212,10 +212,10 @@ func getFilesChanged(gitRoot string, pullBaseSha string, pullPullSha string) ([]
 
 	filesChanged := strings.Fields(string(gitDiffOutput))
 	for _, file := range filesChanged {
-		if strings.Contains(file, "presubmits") {
+		if strings.Contains(file, "presubmits") && strings.HasPrefix(file, "jobs") && strings.HasSuffix(file, "yaml") {
 			presubmitFiles = append(presubmitFiles, file)
 		}
-		if strings.Contains(file, "postsubmits") {
+		if strings.Contains(file, "postsubmits") && strings.HasPrefix(file, "jobs") && strings.HasSuffix(file, "yaml") {
 			postsubmitFiles = append(postsubmitFiles, file)
 		}
 	}


### PR DESCRIPTION
In #252, the logic to generate Prowjobs from templates wil be added. This PR is a precursor to that PR and will invoke the templater logic on that PR before running lint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
