### PR TITLE
Set GOPROXY env var for all Prowjobs

### DIFF
--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -31,8 +31,6 @@ presets:
   env:
   - name: AWS_SDK_LOAD_CONFIG
     value: "true"
-  - name: GOPROXY
-    value: "http://athens-proxy.default.svc.cluster.local"
   volumeMounts:
   - name: docker-registry-config
     readOnly: false
@@ -70,3 +68,5 @@ presets:
     valueFrom:
       fieldRef:
         fieldPath: metadata.name
+  - name: GOPROXY
+    value: "http://athens-proxy.default.svc.cluster.local"


### PR DESCRIPTION
This PR configures the GOPROXY env var for all Prowjobs, regardless of image-building or not.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
