### PR TITLE
Use builder-base to build builder-base

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -48,14 +48,12 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:cb4cb6c153c12a3db8974ad0bea26c9e4eecff97
         command:
         - bash
         - -c
         - >
           scripts/buildkit_check.sh
-          &&
-          ./builder-base/install.sh
           &&
           source scripts/setup_public_ecr_push.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -45,14 +45,12 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:cb4cb6c153c12a3db8974ad0bea26c9e4eecff97
         command:
         - bash
         - -c
         - >
           scripts/buildkit_check.sh
-          &&
-          ./builder-base/install.sh
           &&
           make build -C builder-base
           &&

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -2,9 +2,7 @@ jobName: builder-base-tooling-postsubmit
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 prCreation: true
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 commands:
-- ./builder-base/install.sh
 - source scripts/setup_public_ecr_push.sh
 - make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA
 envVars:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -1,9 +1,7 @@
 jobName: builder-base-tooling-presubmit
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 commands:
-- ./builder-base/install.sh
 - make build -C builder-base
 extraRefs:
 - baseRef: main


### PR DESCRIPTION
Use builder-base as runtime in builder-base Prowjobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
