### PR TITLE
update buildkit-rootless tag to 0.9.3

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -81,7 +81,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -72,7 +72,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1536m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -86,7 +86,7 @@ periodics:
           - date +%s > /status/pending
         periodSeconds: 10
     - name: buildkitd
-      image: moby/buildkit:v0.9.0-rootless
+      image: moby/buildkit:v0.9.3-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -87,7 +87,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
             - date +%s > /status/pending
           periodSeconds: 10
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -72,7 +72,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -72,7 +72,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -72,7 +72,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -72,7 +72,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -72,7 +72,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "25Gi"
             cpu: "3328m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "25Gi"
             cpu: "3328m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "25Gi"
             cpu: "3328m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "25Gi"
             cpu: "3328m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "25Gi"
             cpu: "3328m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-18-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
             memory: "26Gi"
             cpu: "3584m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/templater/main.go
+++ b/templater/main.go
@@ -31,7 +31,7 @@ var editWarning string
 //go:embed BUILDER_BASE_TAG_FILE
 var builderBaseTag string
 
-var buildkitImageTag = "v0.9.0-rootless"
+var buildkitImageTag = "v0.9.3-rootless"
 
 func main() {
 	for _, jobType := range jobTypes {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When building al2022 images there is an issue in resolving dns.  The error appears to have been fixed in 0.9.1 of buildkit.

https://github.com/amazonlinux/amazon-linux-2022/issues/80
https://github.com/moby/buildkit/pull/2379

I will send another PR to update the buildkit cli in the builder base image, but that should not be a pre-req to this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
