### PR TITLE
fix kuberentes presubmit resources requests

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -67,11 +67,11 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
           limits:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -67,11 +67,11 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
           limits:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -67,11 +67,11 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
           limits:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -67,11 +67,11 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
           limits:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -67,11 +67,11 @@ presubmits:
           periodSeconds: 10
         resources:
           requests:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
           limits:
-            memory: "25Gi"
-            cpu: "3328m"
+            memory: "24Gi"
+            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:

--- a/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
@@ -13,8 +13,8 @@ envVars:
   value: localhost:5000
 resources:
   limits:
-    cpu: 3328m
-    memory: 25Gi
+    cpu: 2560m
+    memory: 24Gi
   requests:
-    cpu: 3328m
-    memory: 25Gi
+    cpu: 2560m
+    memory: 24Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With the change to the templater we ended up going over the max cpu for a fargate instance.  This brings the total cpu + mem back to what it was before the templater was added.

Note: we probably want to decrease the buildkit resources across the board, but saving that for a future PR to limit the scope here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
