### PR TITLE
Make livenessprobe less aggressive

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -91,7 +91,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -91,7 +91,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -98,7 +98,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -98,7 +98,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
@@ -119,7 +119,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -119,7 +119,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -92,7 +92,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -92,7 +92,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -92,7 +92,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -92,7 +92,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -92,7 +92,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -82,7 +82,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -86,7 +86,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -141,7 +141,7 @@ periodics:
           command:
           - sh
           - -c
-          - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
         periodSeconds: 15
         initialDelaySeconds: 10
       readinessProbe:

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -130,7 +130,7 @@ postsubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
         securityContext:
           runAsUser: 1000

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -154,7 +154,7 @@ presubmits:
             command:
             - sh
             - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
           periodSeconds: 15
           initialDelaySeconds: 10
         readinessProbe:


### PR DESCRIPTION
Give jobs more time to pass livenessprobe checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
