### PR TITLE
use trap to create /status/done file

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -45,31 +45,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make release -C projects/prometheus/alertmanager IMAGE_TAG=$PULL_BASE_SHA
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/prometheus/alertmanager
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -45,31 +45,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make release -C projects/aws/amazon-eks-pod-identity-webhook IMAGE_TAG=$PULL_BASE_SHA
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/aws/amazon-eks-pod-identity-webhook
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -45,31 +45,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make release -C projects/gomods/athens IMAGE_TAG=$PULL_BASE_SHA
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/gomods/athens
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "2Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -53,13 +53,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           source scripts/setup_public_ecr_push.sh
           &&
           make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2022"
@@ -69,13 +69,6 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         - name: AWS_REGION
           value: "us-east-1"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -86,13 +79,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -53,13 +53,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           source scripts/setup_public_ecr_push.sh
           &&
           make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2"
@@ -69,13 +69,6 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         - name: AWS_REGION
           value: "us-east-1"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -86,13 +79,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -50,21 +50,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C builder-base
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2022"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -50,21 +50,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C builder-base
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -57,6 +57,8 @@ periodics:
       - bash
       - -c
       - >
+        trap 'touch /status/done' EXIT
+        &&
         scripts/buildkit_check.sh
         &&
         export DATE_EPOCH=$(date "+%F-%s")
@@ -66,8 +68,6 @@ periodics:
         make update -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         &&
         make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-        &&
-        touch /status/done
       env:
       - name: AL_TAG
         value: "2022"
@@ -79,26 +79,12 @@ periodics:
         value: "us-east-1"
       - name: REPO_OWNER
         value: "aws"
-      livenessProbe:
-        exec:
-          command:
-          - bash
-          - -c
-          - date +%s > /status/pending
-        periodSeconds: 10
     - name: buildkitd
       image: moby/buildkit:v0.9.3-rootless
       command:
       - sh
       args:
       - /script/entrypoint.sh
-      livenessProbe:
-        exec:
-          command:
-          - sh
-          - -c
-          - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-        periodSeconds: 15
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -57,6 +57,8 @@ periodics:
       - bash
       - -c
       - >
+        trap 'touch /status/done' EXIT
+        &&
         scripts/buildkit_check.sh
         &&
         export DATE_EPOCH=$(date "+%F-%s")
@@ -66,8 +68,6 @@ periodics:
         make update -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         &&
         make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-        &&
-        touch /status/done
       env:
       - name: AL_TAG
         value: "2"
@@ -79,26 +79,12 @@ periodics:
         value: "us-east-1"
       - name: REPO_OWNER
         value: "aws"
-      livenessProbe:
-        exec:
-          command:
-          - bash
-          - -c
-          - date +%s > /status/pending
-        periodSeconds: 10
     - name: buildkitd
       image: moby/buildkit:v0.9.3-rootless
       command:
       - sh
       args:
       - /script/entrypoint.sh
-      livenessProbe:
-        exec:
-          command:
-          - sh
-          - -c
-          - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-        periodSeconds: 15
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -60,6 +60,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           export DATE_EPOCH=$(date "+%F-%s")
@@ -69,8 +71,6 @@ postsubmits:
           make release -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2022"
@@ -80,26 +80,12 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         - name: AWS_REGION
           value: "us-east-1"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -60,6 +60,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           export DATE_EPOCH=$(date "+%F-%s")
@@ -69,8 +71,6 @@ postsubmits:
           make release -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2"
@@ -80,26 +80,12 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         - name: AWS_REGION
           value: "us-east-1"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
@@ -57,6 +57,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           export DATE_EPOCH=$(date "+%F-%s")
@@ -64,20 +66,11 @@ presubmits:
           make build -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -91,13 +84,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -114,14 +100,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -57,6 +57,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           export DATE_EPOCH=$(date "+%F-%s")
@@ -64,20 +66,11 @@ presubmits:
           make build -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C eks-distro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
-          &&
-          touch /status/done
         env:
         - name: AL_TAG
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -91,13 +84,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -114,14 +100,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -45,31 +45,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make release -C projects/infinityworks/github-exporter IMAGE_TAG=$PULL_BASE_SHA
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/infinityworks/github-exporter
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -45,31 +45,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make release -C projects/prometheus/prometheus IMAGE_TAG=$PULL_BASE_SHA
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/prometheus/prometheus
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -50,13 +50,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           source scripts/setup_public_ecr_push.sh
           &&
           make release -C projects/kubernetes/test-infra
-          &&
-          touch /status/done
         env:
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro-build-tooling"
@@ -64,13 +64,6 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         - name: AWS_REGION
           value: "us-east-1"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -47,31 +47,17 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           scripts/buildkit_check.sh
           &&
           make build -C projects/kubernetes/test-infra
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
       - name: buildkitd
         image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-18-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/aws-iam-authenticator
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/aws-iam-authenticator
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/aws-iam-authenticator
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/aws-iam-authenticator
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/aws-iam-authenticator
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-18-postsubmits.yaml
@@ -46,13 +46,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
           make -j2 postsubmit-conformance
-          &&
-          touch /status/done
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"
@@ -70,13 +70,6 @@ postsubmits:
           value: "public.ecr.aws/h1r8a7l5"
         - name: DOCKER_CONFIG
           value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -87,13 +80,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -46,13 +46,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
           make -j2 postsubmit-conformance
-          &&
-          touch /status/done
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"
@@ -70,13 +70,6 @@ postsubmits:
           value: "public.ecr.aws/h1r8a7l5"
         - name: DOCKER_CONFIG
           value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -87,13 +80,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -46,13 +46,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
           make -j2 postsubmit-conformance
-          &&
-          touch /status/done
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"
@@ -70,13 +70,6 @@ postsubmits:
           value: "public.ecr.aws/h1r8a7l5"
         - name: DOCKER_CONFIG
           value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -87,13 +80,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -46,13 +46,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
           make -j2 postsubmit-conformance
-          &&
-          touch /status/done
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"
@@ -70,13 +70,6 @@ postsubmits:
           value: "public.ecr.aws/h1r8a7l5"
         - name: DOCKER_CONFIG
           value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -87,13 +80,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -46,13 +46,13 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
           &&
           make -j2 postsubmit-conformance
-          &&
-          touch /status/done
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::125833916567:role/TestBuildRole"
@@ -70,13 +70,6 @@ postsubmits:
           value: "public.ecr.aws/h1r8a7l5"
         - name: DOCKER_CONFIG
           value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -87,13 +80,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-18-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/coredns/coredns
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/coredns/coredns
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/coredns/coredns
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/coredns/coredns
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -43,23 +43,16 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/coredns/coredns
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -73,13 +66,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-18-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow.sh
-          &&
-          touch /status/done
         env:
         - name: AWS_REGION
           value: "us-east-1"
@@ -60,13 +60,6 @@ postsubmits:
           value: "1-18"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -77,13 +70,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow.sh
-          &&
-          touch /status/done
         env:
         - name: AWS_REGION
           value: "us-east-1"
@@ -60,13 +60,6 @@ postsubmits:
           value: "1-19"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -77,13 +70,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow.sh
-          &&
-          touch /status/done
         env:
         - name: AWS_REGION
           value: "us-east-1"
@@ -60,13 +60,6 @@ postsubmits:
           value: "1-20"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -77,13 +70,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow.sh
-          &&
-          touch /status/done
         env:
         - name: AWS_REGION
           value: "us-east-1"
@@ -60,13 +60,6 @@ postsubmits:
           value: "1-21"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -77,13 +70,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow.sh
-          &&
-          touch /status/done
         env:
         - name: AWS_REGION
           value: "us-east-1"
@@ -60,13 +60,6 @@ postsubmits:
           value: "1-22"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -77,13 +70,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-18-presubmits.yaml
@@ -43,25 +43,18 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/etcd-io/etcd
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -75,13 +68,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -43,25 +43,18 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/etcd-io/etcd
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -75,13 +68,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -43,25 +43,18 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/etcd-io/etcd
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -75,13 +68,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -43,25 +43,18 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/etcd-io/etcd
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -75,13 +68,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -43,25 +43,18 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/etcd-io/etcd
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
           value: "true"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -75,13 +68,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-attacher
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-provisioner
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-resizer
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-snapshotter-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-18-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-snapshotter
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-snapshotter
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-snapshotter
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-snapshotter
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/external-snapshotter
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -44,6 +44,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
@@ -51,20 +53,11 @@ presubmits:
           make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "24Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -101,14 +87,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -44,6 +44,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
@@ -51,20 +53,11 @@ presubmits:
           make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "24Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -101,14 +87,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -44,6 +44,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
@@ -51,20 +53,11 @@ presubmits:
           make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "24Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -101,14 +87,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -44,6 +44,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
@@ -51,20 +53,11 @@ presubmits:
           make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "24Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -101,14 +87,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -44,6 +44,8 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build clean -C projects/kubernetes/release IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
@@ -51,20 +53,11 @@ presubmits:
           make build -C projects/kubernetes/kubernetes
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "24Gi"
@@ -78,13 +71,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -101,14 +87,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/jobs/aws/eks-distro/kubernetes-release-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-18-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes/release
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes/release
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes/release
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes/release
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes/release
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "8Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/livenessprobe
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-18-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/metrics-server
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-18"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/metrics-server
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-19"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/metrics-server
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-20"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/metrics-server
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-21"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -43,21 +43,14 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-sigs/metrics-server
-          &&
-          touch /status/done
         env:
         - name: RELEASE_BRANCH
           value: "1-22"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -71,13 +64,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -43,18 +43,11 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           make build -C projects/kubernetes-csi/node-driver-registrar
-          &&
-          touch /status/done
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "4Gi"
@@ -68,13 +61,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-18-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow-release.sh
-          &&
-          touch /status/done
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
@@ -64,13 +64,6 @@ postsubmits:
           value: "1-18"
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow-release.sh
-          &&
-          touch /status/done
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
@@ -64,13 +64,6 @@ postsubmits:
           value: "1-19"
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow-release.sh
-          &&
-          touch /status/done
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
@@ -64,13 +64,6 @@ postsubmits:
           value: "1-20"
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow-release.sh
-          &&
-          touch /status/done
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
@@ -64,13 +64,6 @@ postsubmits:
           value: "1-21"
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -46,11 +46,11 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           build/lib/buildkit_check.sh
           &&
           ./release/prow-release.sh
-          &&
-          touch /status/done
         env:
         - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
@@ -64,13 +64,6 @@ postsubmits:
           value: "1-22"
         - name: IMAGE_REPO
           value: "public.ecr.aws/eks-distro"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         resources:
           requests:
             memory: "16Gi"
@@ -81,13 +74,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -58,6 +58,8 @@ periodics:
       - -c
       - >
         {{- if .imageBuild }}
+        trap 'touch /status/done' EXIT
+        &&
         {{- if eq .repoName "aws/eks-distro"}}
         build/lib/buildkit_check.sh
         {{- else }}
@@ -66,25 +68,12 @@ periodics:
         &&
         {{- end}}
 {{ .command | indent 8 }}
-        {{- if .imageBuild }}
-        &&
-        touch /status/done
-        {{- end}}
       {{- if .envVars }}
       env:
       {{- range .envVars }}
       - name: {{ .Name }}
         value: "{{ .Value }}"
       {{- end }}
-      {{- end }}
-      {{- if .imageBuild }}
-      livenessProbe:
-        exec:
-          command:
-          - bash
-          - -c
-          - date +%s > /status/pending
-        periodSeconds: 10
       {{- end }}
       {{- if .resources }}
       resources:
@@ -114,13 +103,6 @@ periodics:
       - sh
       args:
       - /script/entrypoint.sh
-      livenessProbe:
-        exec:
-          command:
-          - sh
-          - -c
-          - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-        periodSeconds: 15
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -136,14 +118,6 @@ periodics:
       - sh
       args:
       - /registry-script/entrypoint.sh
-      livenessProbe:
-        exec:
-          command:
-          - sh
-          - -c
-          - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-        periodSeconds: 15
-        initialDelaySeconds: 10
       readinessProbe:
         httpGet:
           path: /

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -69,6 +69,8 @@ postsubmits:
         - -c
         - >
           {{- if .imageBuild }}
+          trap 'touch /status/done' EXIT
+          &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh
           {{- else }}
@@ -77,25 +79,12 @@ postsubmits:
           &&
           {{- end }}
 {{ .command | indent 10 }}
-          {{- if .imageBuild }}
-          &&
-          touch /status/done
-          {{- end }}
         {{- if .envVars }}
         env:
         {{- range .envVars }}
         - name: {{ .Name }}
           value: "{{ .Value }}"
         {{- end }}
-        {{- end }}
-        {{- if .imageBuild }}
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         {{- end }}
         {{- if .resources }}
         resources:
@@ -125,13 +114,6 @@ postsubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -147,14 +129,6 @@ postsubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -68,6 +68,8 @@ presubmits:
         - -c
         - >
           {{- if .imageBuild }}
+          trap 'touch /status/done' EXIT
+          &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh
           {{- else }}
@@ -76,25 +78,12 @@ presubmits:
           &&
           {{- end}}
 {{ .command | indent 10 }}
-          {{- if .imageBuild }}
-          &&
-          touch /status/done
-          {{- end}}
         {{- if .envVars }}
         env:
         {{- range .envVars }}
         - name: {{ .Name }}
           value: "{{ .Value }}"
         {{- end }}
-        {{- end }}
-        {{- if .imageBuild }}
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - date +%s > /status/pending
-          periodSeconds: 10
         {{- end }}
         {{- if .resources }}
         resources:
@@ -124,13 +113,6 @@ presubmits:
         - sh
         args:
         - /script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
-          periodSeconds: 15
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -149,14 +131,6 @@ presubmits:
         - sh
         args:
         - /registry-script/entrypoint.sh
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test $(($(date +%s) - 30)) -lt $(cat /status/pending)
-          periodSeconds: 15
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The livenessprobe tech seems a bit brittle, tho to be fair it has served us well.  While debugging a recent issue we thought was the livenessprobe, which ended up not being the case, this solution of using TRAP instead was found.  I *think* this may be a better approach...

More info: https://carlosbecker.com/posts/k8s-sidecar-shutdown/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
