### PR TITLE
eks-distro attribution: bump timeout up to handle new kube build

### DIFF
--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -27,6 +27,7 @@ periodics:
     repo: eks-distro
     base_ref: main
   decoration_config:
+    timeout: 4h
     gcs_configuration:
       bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
       path_strategy: explicit

--- a/templater/jobs/periodic/eks-distro/attribution-files-periodics.yaml
+++ b/templater/jobs/periodic/eks-distro/attribution-files-periodics.yaml
@@ -14,3 +14,4 @@ resources:
   requests:
     cpu: "4"
     memory: 16Gi
+timeout: 4h


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
