### PR TITLE
Enable garbage collection on buildkit worker

### DIFF
--- a/scripts/buildkitd-entrypoint.sh
+++ b/scripts/buildkitd-entrypoint.sh
@@ -21,6 +21,8 @@ rootlesskit \
 	--oci-worker-no-process-sandbox \
 	--oci-worker-platform=linux/amd64 \
 	--oci-worker-platform=linux/arm64 \
+	--oci-worker-gc \
+	--oci-worker-gc-keepstorage 1000 \
 	&
 pid=$!
 while [ ! -f /status/done ]


### PR DESCRIPTION
This enables garbage collection on the buildkit worker to clean local builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
