### PR TITLE
Set builder-base image as env var in Prowjobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -34,6 +34,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -34,6 +34,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -34,6 +34,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: charts-build-account

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -41,6 +41,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       pr-creation: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -41,6 +41,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       pr-creation: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -39,6 +39,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -39,6 +39,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -45,6 +45,7 @@ periodics:
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   labels:
+    ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     image-build: "true"
     pr-creation: "true"
   spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -45,6 +45,7 @@ periodics:
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   labels:
+    ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     image-build: "true"
     pr-creation: "true"
   spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -48,6 +48,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       pr-creation: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -48,6 +48,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       pr-creation: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
@@ -45,6 +45,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -45,6 +45,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -47,6 +47,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       pr-creation: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -34,6 +34,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -34,6 +34,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -38,6 +38,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       pr-creation: "true"
     spec:

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -36,6 +36,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/announcement-postsubmits.yaml
+++ b/jobs/aws/eks-distro/announcement-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -33,6 +33,7 @@ periodics:
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   labels:
+    ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     pr-creation: "true"
   spec:
     serviceaccountName: periodics-build-account

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
@@ -33,6 +33,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: docs-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro/kubernetes-1-19-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-test-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro/kubernetes-1-20-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-test-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: release-build-account

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: release-build-account

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: release-build-account

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: release-build-account

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -88,3 +88,7 @@ presets:
         fieldPath: metadata.name
   - name: GOPROXY
     value: "http://athens-proxy.default.svc.cluster.local"
+  - name: CI_BUILD_IMAGE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['ci-build-image']

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -35,8 +35,8 @@ periodics:
       bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
-  {{- if or .imageBuild .localRegistry .prCreation }}
   labels:
+    ci-build-image: {{ or .runtimeImage $builderBaseImage }}
     {{- if .imageBuild }}
     image-build: "true"
     {{- end }}
@@ -46,7 +46,6 @@ periodics:
     {{- if .prCreation }}
     pr-creation: "true"
     {{- end }}
-  {{- end }}
   spec:
     serviceaccountName: {{ or .serviceAccountName "periodics-build-account" }}
     automountServiceAccountToken: false

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -46,8 +46,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    {{- if or .imageBuild .localRegistry .prCreation }}
     labels:
+      ci-build-image: {{ or .runtimeImage $builderBaseImage }}
       {{- if .imageBuild }}
       image-build: "true"
       {{- end }}
@@ -57,7 +57,6 @@ postsubmits:
       {{- if .prCreation }}
       pr-creation: "true"
       {{- end }}
-    {{- end }}
     spec:
       serviceaccountName: {{ or .serviceAccountName "postsubmits-build-account" }}
       automountServiceAccountToken: false

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -45,8 +45,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    {{- if or .imageBuild .localRegistry .prCreation }}
     labels:
+      ci-build-image: {{ or .runtimeImage $builderBaseImage }}
       {{- if .imageBuild }}
       image-build: "true"
       {{- end }}
@@ -56,7 +56,6 @@ presubmits:
       {{- if .prCreation }}
       pr-creation: "true"
       {{- end }}
-    {{- end }}
     spec:
       serviceaccountName: {{ or .serviceAccountName "presubmits-build-account" }}
       automountServiceAccountToken: false


### PR DESCRIPTION
Adding builder-base image value as an env var in Prowjobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
