### PR TITLE
Mount BUILDER_BASE_TAG_FILE onto Prowjob pods as ConfigMap

### DIFF
--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -88,3 +88,14 @@ presets:
         fieldPath: metadata.name
   - name: GOPROXY
     value: "http://athens-proxy.default.svc.cluster.local"
+  volumes:
+  - name: builder-base-tag-file
+    configMap:
+      name: builder-base-tag-file
+      items:
+      - key: BUILDER_BASE_TAG_FILE
+        path: BUILDER_BASE_TAG_FILE
+  volumeMounts:
+  - name: builder-base-tag-file
+    readOnly: false
+    mountPath: /config

--- a/scripts/buildkitd-entrypoint.sh
+++ b/scripts/buildkitd-entrypoint.sh
@@ -22,7 +22,7 @@ rootlesskit \
 	--oci-worker-platform=linux/amd64 \
 	--oci-worker-platform=linux/arm64 \
 	--oci-worker-gc \
-	--oci-worker-gc-keepstorage 1000 \
+	--oci-worker-gc-keepstorage 15000 \
 	&
 pid=$!
 while [ ! -f /status/done ]


### PR DESCRIPTION
Mount BUILDER_BASE_TAG_FILE onto Prowjob pods as ConfigMap so we can refer to it in scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
