### PR TITLE
properly handle running out of disk space in presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -50,7 +50,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
@@ -57,7 +57,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           scripts/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
         - -c
         - >
           {{- if .imageBuild }}
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently if a job runs out of disk space in presubmit, which is pretty much only ever happened in the kubernetes build, prow does not usually exit cleanly.  Prow creates a marker file which the sidecar container looks for to determine when the build is complete.  When the disk is full, this marker cannot be created and the sidecar will hang until killed 24 hrs later.  This attempts to handle that by freeing up some disk space in our trap function.  Deleting the prow folder should be fine at this point since the only data that is going to get looked at after the build container exits is whatever is in /logs/artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
