### PR TITLE
Reduce Buildkit GC storage to 5 GB

### DIFF
--- a/scripts/buildkitd-entrypoint.sh
+++ b/scripts/buildkitd-entrypoint.sh
@@ -22,7 +22,7 @@ rootlesskit \
 	--oci-worker-platform=linux/amd64 \
 	--oci-worker-platform=linux/arm64 \
 	--oci-worker-gc \
-	--oci-worker-gc-keepstorage 15000 \
+	--oci-worker-gc-keepstorage 5000 \
 	&
 pid=$!
 while [ ! -f /status/done ]


### PR DESCRIPTION
De-clutter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
