### PR TITLE
Bump buildkit rootless image tag to v0.10.1 in Prowjobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -51,7 +51,7 @@ postsubmits:
           &&
           make release -C projects/prometheus/alertmanager IMAGE_TAG=$PULL_BASE_SHA
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -51,7 +51,7 @@ postsubmits:
           &&
           make release -C projects/aws/amazon-eks-pod-identity-webhook IMAGE_TAG=$PULL_BASE_SHA
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -51,7 +51,7 @@ postsubmits:
           &&
           make release -C projects/gomods/athens IMAGE_TAG=$PULL_BASE_SHA
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "2Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -74,7 +74,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1536m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1536m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -80,7 +80,7 @@ periodics:
       - name: REPO_OWNER
         value: "aws"
     - name: buildkitd
-      image: moby/buildkit:v0.9.3-rootless
+      image: moby/buildkit:v0.10.1-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -80,7 +80,7 @@ periodics:
       - name: REPO_OWNER
         value: "aws"
     - name: buildkitd
-      image: moby/buildkit:v0.9.3-rootless
+      image: moby/buildkit:v0.10.1-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -85,7 +85,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -85,7 +85,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmit-2022.yaml
@@ -79,7 +79,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -51,7 +51,7 @@ postsubmits:
           &&
           make release -C projects/infinityworks/github-exporter IMAGE_TAG=$PULL_BASE_SHA
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -51,7 +51,7 @@ postsubmits:
           &&
           make release -C projects/prometheus/prometheus IMAGE_TAG=$PULL_BASE_SHA
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -69,7 +69,7 @@ postsubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
           &&
           make build -C projects/kubernetes/test-infra
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-19-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -75,7 +75,7 @@ postsubmits:
             memory: "8Gi"
             cpu: "2"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -75,7 +75,7 @@ postsubmits:
             memory: "8Gi"
             cpu: "2"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -75,7 +75,7 @@ postsubmits:
             memory: "8Gi"
             cpu: "2"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -75,7 +75,7 @@ postsubmits:
             memory: "8Gi"
             cpu: "2"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-19-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-19-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-19-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "24Gi"
             cpu: "2560m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "24Gi"
             cpu: "2560m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "24Gi"
             cpu: "2560m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             memory: "24Gi"
             cpu: "2560m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-19-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -69,7 +69,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -69,7 +69,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -69,7 +69,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -69,7 +69,7 @@ postsubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.3-rootless
+        image: moby/buildkit:v0.10.1-rootless
         command:
         - sh
         args:

--- a/templater/main.go
+++ b/templater/main.go
@@ -33,7 +33,7 @@ var editWarning string
 //go:embed BUILDER_BASE_TAG_FILE
 var builderBaseTag string
 
-var buildkitImageTag = "v0.9.3-rootless"
+var buildkitImageTag = "v0.10.1-rootless"
 
 func main() {
 	jobsFolderPath, err := getJobsFolderPath()


### PR DESCRIPTION
The [`v0.10.0`](https://github.com/moby/buildkit/releases/tag/v0.10.0) release of Buildkit comes with a bunch of fixes and improvements to build size/GC/logs that could be useful to us.

Bumping to the latest Buildkit version available, that includes changes that went into `v0.10.0`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
