### PR TITLE
Force jobs running on actual nodes to error out on pod eviction

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-distro-base-tooling-periodic-2022
   cron: "0 19 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   extra_refs:
   - org: aws
     repo: eks-distro-build-tooling

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-distro-base-tooling-periodic
   cron: "0 19 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   extra_refs:
   - org: aws
     repo: eks-distro-build-tooling

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-distro/announcement-postsubmits.yaml
+++ b/jobs/aws/eks-distro/announcement-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/attribution-files-periodics.yaml
+++ b/jobs/aws/eks-distro/attribution-files-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: attribution-files-periodic
   cron: "0 18 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   extra_refs:
   - org: aws
     repo: eks-distro

--- a/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-19-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-19-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 10
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-19-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^main$
     max_concurrency: 1
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -19,6 +19,7 @@ periodics:
 - name: {{ .prowjobName }}
   cron: "{{ .cronExpression }}"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   {{- if .extraRefs }}
   extra_refs:
   {{- range .extraRefs }}

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -32,6 +32,7 @@ postsubmits:
     {{- end }}
     {{- end }}
     max_concurrency: {{or .maxConcurrency 10 }}
+    error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     {{- if .extraRefs }}


### PR DESCRIPTION
We don't want Prowjobs to keep restarting every time the job Pods get evicted from the node due to reasons like lack of disk space, exceeding resource limits etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
