### PR TITLE
Bumps kops jobs limits

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
@@ -49,6 +49,3 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
@@ -44,8 +44,8 @@ presubmits:
           make build -C projects/kubernetes/kops ARTIFACTS_BUCKET="eks-d-postsubmit-artifacts"
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
+            memory: "16Gi"
+            cpu: "2560m"
           limits:
-            memory: "2Gi"
-            cpu: "1024m"
+            memory: "16Gi"
+            cpu: "2560m"

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/kops-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/kops-postsubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: false
 commands:
 - make release -C projects/kubernetes/kops ARTIFACTS_BUCKET="eks-d-postsubmit-artifacts"
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/kops-presubmits.yaml
@@ -4,8 +4,8 @@ commands:
 - make build -C projects/kubernetes/kops ARTIFACTS_BUCKET="eks-d-postsubmit-artifacts"
 resources:
   limits:
-    cpu: 1024m
-    memory: 2Gi
+    cpu: "2560m"
+    memory: 16Gi
   requests:
-    cpu: 1024m
-    memory: 2Gi
+    cpu: "2560m"
+    memory: 16Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The postsubmit job was getting killed due to the low resource limits. The presubmit was taking 30 mins...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
