### PR TITLE
add skip privd tests env var to golang presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -45,6 +45,8 @@ presubmits:
         env:
         - name: GO_SOURCE_VERSION
           value: "1.15"
+        - name: SKIP_PRIVILEGED_TESTS
+          value: "true"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -12,3 +12,5 @@ resources:
 envVars:
   - name: GO_SOURCE_VERSION
     value: 1.15
+  - name: SKIP_PRIVILEGED_TESTS
+    value: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We don't want to run some priv'd tests (such as unshare tests) in the presubmits, as they will fail due to permissions errors int he unpriv'd execution environment. Adding an env var that we can check in the tests to determine wether to run the priv'd tests or not.

Tried using the fargate AWS_EXECUTION_ENV env var to determine this but it's not being set in our cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
