### PR TITLE
add dep install to go build presub

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -41,6 +41,8 @@ presubmits:
         - bash
         - -c
         - >
+          make install-deps
+          &&
           make build -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
         - bash
         - -c
         - >
-          make install-deps
+          make install-deps -C projects/golang/go
           &&
           make build -C projects/golang/go
         env:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -1,7 +1,7 @@
 jobName: golang-1.15-tooling-presubmit
 runIfChanged: projects/golang/go/1.15/.*
 commands:
-- make install-deps
+- make install-deps -C projects/golang/go
 - make build -C projects/golang/go
 resources:
   limits:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -1,6 +1,7 @@
 jobName: golang-1.15-tooling-presubmit
 runIfChanged: projects/golang/go/1.15/.*
 commands:
+- make install-deps
 - make build -C projects/golang/go
 resources:
   limits:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
install deps in presub for go build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
