### PR TITLE
use al2 for golang rpm build

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
         command:
         - bash
         - -c

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -1,5 +1,6 @@
 jobName: golang-1.15-tooling-presubmit
 runIfChanged: projects/golang/go/1.15/.*
+runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 commands:
 - make build -C projects/golang/go
 resources:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use al2 as base for go to avoid dep install issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
