### PR TITLE
add artifacts bucket env var to presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -49,6 +49,8 @@ presubmits:
           value: "1.15"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
+        - name: ARTIFACTS_BUCKET
+          value: "eks-d-postsubmit-artifacts"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -16,3 +16,5 @@ envVars:
     value: 1.15
   - name: SKIP_PRIVILEGED_TESTS
     value: true
+  - name: ARTIFACTS_BUCKET
+    value: eks-d-postsubmit-artifacts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
need this env var in the pre-sub now that we're running the dry-run of the artifacts sync to s3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
