### PR TITLE
Make prow job system architecture configurable

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -39,6 +39,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -39,6 +39,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -39,6 +39,8 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -47,6 +47,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -47,6 +47,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -54,6 +54,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -54,6 +54,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -52,6 +52,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -39,6 +39,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -39,6 +39,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -44,6 +44,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/announcement-postsubmits.yaml
+++ b/jobs/aws/eks-distro/announcement-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-20-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-20-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/dev-release-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-24-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
@@ -37,6 +37,8 @@ postsubmits:
     spec:
       serviceaccountName: docs-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-20-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/jobs/aws/eks-distro/prod-release-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-24-postsubmits.yaml
@@ -40,6 +40,8 @@ postsubmits:
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2

--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -45,6 +45,7 @@ type VolumeMount struct {
 }
 
 type JobConfig struct {
+	Architecture       string         `json:"architecture,omitempty"`
 	JobName            string         `json:"jobName,omitempty"`
 	RunIfChanged       string         `json:"runIfChanged,omitempty"`
 	SkipIfOnlyChanged  string         `json:"skipIfOnlyChanged,omitempty"`

--- a/templater/main.go
+++ b/templater/main.go
@@ -64,6 +64,7 @@ func main() {
 		for repoName, jobConfigs := range jobList {
 			for fileName, jobConfig := range jobConfigs {
 				data := map[string]interface{}{
+					"architecture":       jobConfig.Architecture,
 					"repoName":           repoName,
 					"prowjobName":        jobConfig.JobName,
 					"runIfChanged":       jobConfig.RunIfChanged,

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -66,6 +66,8 @@ postsubmits:
     spec:
       serviceaccountName: {{ or .serviceAccountName "postsubmits-build-account" }}
       automountServiceAccountToken: false
+      nodeSelector:
+        arch: {{ or .architecture "AMD64" }}
       containers:
       - name: build-container
         image: {{ or .runtimeImage $builderBaseImage }}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/240

*Description of changes:*
Add an option to specify an architecture to EKS-D prow jobs. This defaults to `AMD64`.

This will specify a node selector which corresponds to the architecture of the underlying node.

A forthcomming PR will include full support for ARM64 node selectors and updates to the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
