### PR TITLE
use unique name for go arm64 prow postsubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
@@ -20,7 +20,7 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.16-tooling-postsubmit
+  - name: golang-1.16-ARM64-tooling-postsubmit
     always_run: false
     run_if_changed: "projects/golang/go/1.16/.*"
     branches:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
@@ -1,4 +1,4 @@
-jobName: golang-1.16-tooling-postsubmit
+jobName: golang-1.16-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.16/.*
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/240

*Description of changes:*
need to make sure the ARM post-submit name is unique

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
