### PR TITLE
Limit mount of docker config

### DIFF
--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -50,9 +50,9 @@ presets:
   - name: AWS_SDK_LOAD_CONFIG
     value: "true"
   volumeMounts:
-  - name: docker-registry-config
-    readOnly: false
-    mountPath: /root/.docker
+  - name: docker-registry-config    
+    mountPath: /root/.docker/config.json
+    subPath: config.json
   - name: run-buildkit
     readOnly: false
     mountPath: /run/buildkit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The way we currently mount the docker config file takes over the entire ~/.docker/ directory and makes it readonly since that is how configmaps are mounted.  This makes it impossible to change other docker settings during builds, like when using buildx and it tries to store its config there.  Using this subpath option *should* fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
