### PR TITLE
add prod release post-submits for Golang

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.15-ARM64-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.15/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -50,14 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.15"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
         resources:

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.15-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.15/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -38,7 +38,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       nodeSelector:
-        arch: ARM64
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2
@@ -50,16 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.15"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
-        - name: ARCHITECTURE
-          value: "ARM64"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.16-ARM64-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.16/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -50,14 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.16"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
         resources:

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.16-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.16/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -38,7 +38,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       nodeSelector:
-        arch: ARM64
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2
@@ -50,16 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.16"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
-        - name: ARCHITECTURE
-          value: "ARM64"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.17-ARM64-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.17/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -50,14 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
           value: "1.17"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
         resources:

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.17-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.17/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -38,7 +38,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       nodeSelector:
-        arch: ARM64
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2
@@ -50,16 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
           value: "1.17"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
-        - name: ARCHITECTURE
-          value: "ARM64"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.18-ARM64-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.18/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -50,14 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.18"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
         resources:

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.18-ARM64-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.16/.*"
+    run_if_changed: "projects/golang/go/1.18/.*"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro-build-tooling:
-  - name: golang-1.17-ARM64-tooling-postsubmit
+  - name: golang-1.18-PROD-tooling-postsubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/1.18/RELEASE"
     branches:
     - ^main$
     max_concurrency: 10
@@ -38,7 +38,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       nodeSelector:
-        arch: ARM64
+        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/amazonlinux/amazonlinux:2
@@ -50,16 +50,14 @@ postsubmits:
           &&
           make install-deps -C projects/golang/go
           &&
-          make release -C projects/golang/go
+          make prod-release -C projects/golang/go
         env:
         - name: GO_SOURCE_VERSION
-          value: "1.17"
+          value: "1.18"
         - name: SKIP_PRIVILEGED_TESTS
           value: "true"
         - name: ARTIFACTS_BUCKET
-          value: "eks-d-postsubmit-artifacts"
-        - name: ARCHITECTURE
-          value: "ARM64"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -1,11 +1,11 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.15-ARM64-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.15/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +15,10 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.15
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -1,11 +1,10 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.15-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.15/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
-architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +14,8 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.15
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
-  - name: ARCHITECTURE
-    value: ARM64
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -1,11 +1,11 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.16-ARM64-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.16/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +15,10 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.16
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -1,11 +1,10 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.16-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.16/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
-architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +14,8 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.16
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
-  - name: ARCHITECTURE
-    value: ARM64
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -1,11 +1,11 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.17-ARM64-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.17/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -19,6 +19,6 @@ envVars:
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -1,11 +1,10 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.17-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.17/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
-architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -19,6 +18,4 @@ envVars:
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
-  - name: ARCHITECTURE
-    value: ARM64
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -1,11 +1,11 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.18-ARM64-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.18/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +15,10 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.18
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
@@ -1,5 +1,5 @@
 jobName: golang-1.18-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.16/.*
+runIfChanged: projects/golang/go/1.18/.*
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 architecture: ARM64
 commands:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -1,11 +1,10 @@
-jobName: golang-1.17-ARM64-tooling-postsubmit
-runIfChanged: projects/golang/go/1.17/.*
+jobName: golang-1.18-PROD-tooling-postsubmit
+runIfChanged: projects/golang/go/1.18/RELEASE
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
-architecture: ARM64
 commands:
 - yum -y install make
 - make install-deps -C projects/golang/go
-- make release -C projects/golang/go
+- make prod-release -C projects/golang/go
 resources:
   limits:
     cpu: 2560m
@@ -15,10 +14,8 @@ resources:
     memory: 16Gi
 envVars:
   - name: GO_SOURCE_VERSION
-    value: 1.17
+    value: 1.18
   - name: SKIP_PRIVILEGED_TESTS
     value: true
   - name: ARTIFACTS_BUCKET
-    value: eks-d-postsubmit-artifacts
-  - name: ARCHITECTURE
-    value: ARM64
+    value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/241

*Description of changes:*
Add post-submits for each version of Go, which will:
- on changes to the `RELEASE` tag for the given version
- execute a build
- upload the built RPMs to the prod actifacts bucket at the path `golang-$VERSION/releases/$RELEASE_NUMBER/RPMS`

We can then use these stable RPMs as the released, prod versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
