### PR TITLE
add prod release config to Go release prow jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: ARM64
@@ -60,6 +60,10 @@ postsubmits:
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: AMD64
@@ -58,6 +58,10 @@ postsubmits:
           value: "true"
         - name: ARTIFACTS_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: ARM64
@@ -60,6 +60,10 @@ postsubmits:
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: AMD64
@@ -58,6 +58,10 @@ postsubmits:
           value: "true"
         - name: ARTIFACTS_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: ARM64
@@ -60,6 +60,10 @@ postsubmits:
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: AMD64
@@ -58,6 +58,10 @@ postsubmits:
           value: "true"
         - name: ARTIFACTS_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: ARM64
@@ -60,6 +60,10 @@ postsubmits:
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: ARCHITECTURE
           value: "ARM64"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: AMD64
@@ -58,6 +58,10 @@ postsubmits:
           value: "true"
         - name: ARTIFACTS_BUCKET
           value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -22,3 +22,8 @@ envVars:
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -19,3 +19,8 @@ envVars:
     value: true
   - name: ARTIFACTS_BUCKET
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -22,3 +22,8 @@ envVars:
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -19,3 +19,8 @@ envVars:
     value: true
   - name: ARTIFACTS_BUCKET
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -22,3 +22,8 @@ envVars:
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -19,3 +19,8 @@ envVars:
     value: true
   - name: ARTIFACTS_BUCKET
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -22,3 +22,8 @@ envVars:
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARCHITECTURE
     value: ARM64
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -19,3 +19,8 @@ envVars:
     value: true
   - name: ARTIFACTS_BUCKET
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
+  - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+    value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+serviceAccountName: release-build-account


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/241

*Description of changes:*
Add release config for Golang release prow jobs, setting the environment variables and service accounts necessary in order to access the prod artifacts bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
