### PR TITLE
Runs builder-base presubmit on postsubmit cluster

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -51,16 +51,16 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2
+        image: public.ecr.aws/amazonlinux/amazonlinux:2022
         command:
         - bash
         - -c
         - >
           trap 'touch /status/done' EXIT
           &&
-          scripts/buildkit_check.sh
-          &&
           source scripts/setup_public_ecr_push.sh
+          &&
+          ./builder-base/install.sh
           &&
           make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
         env:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -51,16 +51,16 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:9242630ce031e03158c65753c07bbfc79985347e.2
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
         command:
         - bash
         - -c
         - >
           trap 'touch /status/done' EXIT
           &&
-          scripts/buildkit_check.sh
-          &&
           source scripts/setup_public_ecr_push.sh
+          &&
+          ./builder-base/install.sh
           &&
           make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
         env:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -24,7 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
-    cluster: "prow-presubmits-cluster"
+    cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:
     - org: eks-distro-pr-bot
@@ -35,13 +35,13 @@ presubmits:
       base_ref: main
     decoration_config:
       gcs_configuration:
-        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
     spec:
-      serviceaccountName: presubmits-build-account
+      serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       containers:
       - name: build-container
@@ -52,21 +52,12 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          scripts/buildkit_check.sh
-          &&
           ./builder-base/install.sh
           &&
           make build -C builder-base
         env:
         - name: AL_TAG
           value: "2022"
-        resources:
-          requests:
-            memory: "16Gi"
-            cpu: "14976m"
-          limits:
-            memory: "16Gi"
-            cpu: "14976m"
       - name: buildkitd
         image: moby/buildkit:v0.10.1-rootless
         command:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh"
     max_concurrency: 10
-    cluster: "prow-presubmits-cluster"
+    cluster: "prow-postsubmits-cluster"
     skip_report: false
     extra_refs:
     - org: eks-distro-pr-bot
@@ -35,13 +35,13 @@ presubmits:
       base_ref: main
     decoration_config:
       gcs_configuration:
-        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
     spec:
-      serviceaccountName: presubmits-build-account
+      serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       containers:
       - name: build-container
@@ -52,21 +52,12 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          scripts/buildkit_check.sh
-          &&
           ./builder-base/install.sh
           &&
           make build -C builder-base
         env:
         - name: AL_TAG
           value: "2"
-        resources:
-          requests:
-            memory: "16Gi"
-            cpu: "14"
-          limits:
-            memory: "16Gi"
-            cpu: "14"
       - name: buildkitd
         image: moby/buildkit:v0.10.1-rootless
         command:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -1,9 +1,12 @@
 jobName: builder-base-tooling-postsubmit-2022
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
+runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2022
 imageBuild: true
 prCreation: true
+skipBuldkitCheck: true
 commands:
 - source scripts/setup_public_ecr_push.sh
+- ./builder-base/install.sh
 - make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
 envVars:
 - name: AL_TAG

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -3,7 +3,7 @@ runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_p
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2022
 imageBuild: true
 prCreation: true
-skipBuldkitCheck: true
+skipBuildkitCheck: true
 commands:
 - source scripts/setup_public_ecr_push.sh
 - ./builder-base/install.sh

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -1,9 +1,12 @@
 jobName: builder-base-tooling-postsubmit
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
+runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 imageBuild: true
 prCreation: true
+skipBuldkitCheck: true
 commands:
 - source scripts/setup_public_ecr_push.sh
+- ./builder-base/install.sh
 - make release -C builder-base IMAGE_TAG=$PULL_BASE_SHA.${AL_TAG}
 envVars:
 - name: AL_TAG

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -3,7 +3,7 @@ runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_p
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 imageBuild: true
 prCreation: true
-skipBuldkitCheck: true
+skipBuildkitCheck: true
 commands:
 - source scripts/setup_public_ecr_push.sh
 - ./builder-base/install.sh

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -2,7 +2,7 @@ jobName: builder-base-tooling-presubmit-2022
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2022
 imageBuild: true
-skipBuldkitCheck: true
+skipBuildkitCheck: true
 cluster: prow-postsubmits-cluster
 commands:
 - ./builder-base/install.sh

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -2,6 +2,8 @@ jobName: builder-base-tooling-presubmit-2022
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2022
 imageBuild: true
+skipBuldkitCheck: true
+cluster: prow-postsubmits-cluster
 commands:
 - ./builder-base/install.sh
 - make build -C builder-base
@@ -15,10 +17,3 @@ extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot
   repo: eks-anywhere-prow-jobs
-resources:
-  limits:
-    cpu: 14976m
-    memory: 16Gi
-  requests:
-    cpu: 14976m
-    memory: 16Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: builder-base-tooling-presubmit
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 imageBuild: true
-skipBuldkitCheck: true
+skipBuildkitCheck: true
 cluster: prow-postsubmits-cluster
 commands:
 - ./builder-base/install.sh

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -2,6 +2,8 @@ jobName: builder-base-tooling-presubmit
 runIfChanged: builder-base/.*|generate-attribution/.*|scripts/setup_public_ecr_push.sh
 runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
 imageBuild: true
+skipBuldkitCheck: true
+cluster: prow-postsubmits-cluster
 commands:
 - ./builder-base/install.sh
 - make build -C builder-base
@@ -15,10 +17,4 @@ extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot
   repo: eks-anywhere-prow-jobs
-resources:
-  limits:
-    cpu: 14
-    memory: 16Gi
-  requests:
-    cpu: 14
-    memory: 16Gi
+

--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -67,5 +67,5 @@ type JobConfig struct {
 	Volumes                      []*Volume      `json:"volumes,omitempty"`
 	AutomountServiceAccountToken string         `json:"automountServiceAccountToken,omitempty"`
 	Cluster                      string         `json:"cluster,omitempty"`
-	SkipBuldkitCheck             bool           `json:"skipBuldkitCheck,omitempty"`
+	SkipBuildkitCheck            bool           `json:"skipBuildkitCheck,omitempty"`
 }

--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -66,4 +66,6 @@ type JobConfig struct {
 	VolumeMounts                 []*VolumeMount `json:"volumeMounts,omitempty"`
 	Volumes                      []*Volume      `json:"volumes,omitempty"`
 	AutomountServiceAccountToken string         `json:"automountServiceAccountToken,omitempty"`
+	Cluster                      string         `json:"cluster,omitempty"`
+	SkipBuldkitCheck             bool           `json:"skipBuldkitCheck,omitempty"`
 }

--- a/templater/main.go
+++ b/templater/main.go
@@ -75,6 +75,8 @@ func main() {
 					branches = append(branches, "^main$")
 				}
 
+				cluster, bucket, serviceAccountName := clusterDetails(jobType, jobConfig.Cluster, jobConfig.ServiceAccountName)
+
 				data := map[string]interface{}{
 					"architecture":                 jobConfig.Architecture,
 					"repoName":                     repoName,
@@ -91,7 +93,7 @@ func main() {
 					"prCreation":                   jobConfig.PRCreation,
 					"runtimeImage":                 jobConfig.RuntimeImage,
 					"localRegistry":                jobConfig.LocalRegistry,
-					"serviceAccountName":           jobConfig.ServiceAccountName,
+					"serviceAccountName":           serviceAccountName,
 					"command":                      strings.Join(jobConfig.Commands, "\n&&\n"),
 					"builderBaseTag":               builderBaseTag,
 					"buildkitImageTag":             buildkitImageTag,
@@ -101,6 +103,9 @@ func main() {
 					"volumeMounts":                 jobConfig.VolumeMounts,
 					"editWarning":                  editWarning,
 					"automountServiceAccountToken": jobConfig.AutomountServiceAccountToken,
+					"cluster":                      cluster,
+					"bucket":                       bucket,
+					"skipBuldkitCheck":             jobConfig.SkipBuldkitCheck,
 				}
 
 				err := GenerateProwjob(fileName, template, data)
@@ -157,4 +162,24 @@ func useTemplate(jobType string) (string, error) {
 	default:
 		return "", fmt.Errorf("Unsupported job type: %s", jobType)
 	}
+}
+
+func clusterDetails(jobType string, cluster string, serviceAccountName string) (string, string, string) {
+	if cluster == "prow-postsubmits-cluster" {
+		jobType = "postsubmit"
+	}
+
+	cluster = "prow-presubmits-cluster"
+	bucket := "s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp"
+
+	if jobType == "postsubmit" || jobType == "periodic" {
+		cluster = "prow-postsubmits-cluster"
+		bucket = "s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm"
+	}
+
+	if len(serviceAccountName) == 0 {
+		serviceAccountName = jobType + "s-build-account"
+	}
+
+	return cluster, bucket, serviceAccountName
 }

--- a/templater/main.go
+++ b/templater/main.go
@@ -105,7 +105,7 @@ func main() {
 					"automountServiceAccountToken": jobConfig.AutomountServiceAccountToken,
 					"cluster":                      cluster,
 					"bucket":                       bucket,
-					"skipBuldkitCheck":             jobConfig.SkipBuldkitCheck,
+					"skipBuildkitCheck":            jobConfig.SkipBuildkitCheck,
 				}
 
 				err := GenerateProwjob(fileName, template, data)

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -18,7 +18,7 @@
 periodics:
 - name: {{ .prowjobName }}
   cron: "{{ .cronExpression }}"
-  cluster: "prow-postsubmits-cluster"
+  cluster: "{{ .cluster }}"
   error_on_eviction: true
   {{- if .extraRefs }}
   extra_refs:
@@ -33,7 +33,7 @@ periodics:
     timeout: {{ .timeout }}
     {{- end }}
     gcs_configuration:
-      bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+      bucket: {{ .bucket }}
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
   {{- if or .imageBuild .localRegistry .prCreation }}
@@ -49,7 +49,7 @@ periodics:
     {{- end }}
   {{- end }}
   spec:
-    serviceaccountName: {{ or .serviceAccountName "periodics-build-account" }}
+    serviceaccountName: {{ .serviceAccountName }}
     automountServiceAccountToken: false
     containers:
     - name: build-container

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -76,7 +76,7 @@ postsubmits:
         - >
           {{- if .imageBuild }}
           trap '{{- if .useDockerBuildX }}(docker buildx rm eks-d-builders || true) && {{ end }}touch /status/done' EXIT
-          {{- if not .skipBuldkitCheck }}
+          {{- if not .skipBuildkitCheck }}
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -32,7 +32,7 @@ postsubmits:
     {{- end }}
     max_concurrency: {{or .maxConcurrency 10 }}
     error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "{{ .cluster }}"
     skip_report: false
     {{- if .extraRefs }}
     extra_refs:
@@ -47,7 +47,7 @@ postsubmits:
       timeout: {{ .timeout }}
       {{- end }}
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: {{ .bucket }}
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     {{- if or .imageBuild .localRegistry .prCreation }}
@@ -63,7 +63,7 @@ postsubmits:
       {{- end }}
     {{- end }}
     spec:
-      serviceaccountName: {{ or .serviceAccountName "postsubmits-build-account" }}
+      serviceaccountName: {{ .serviceAccountName }}
       automountServiceAccountToken: {{ or .automountServiceAccountToken false}}
       nodeSelector:
         arch: {{ or .architecture "AMD64" }}
@@ -76,11 +76,13 @@ postsubmits:
         - >
           {{- if .imageBuild }}
           trap '{{- if .useDockerBuildX }}(docker buildx rm eks-d-builders || true) && {{ end }}touch /status/done' EXIT
+          {{- if not .skipBuldkitCheck }}
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh
           {{- else }}
           scripts/buildkit_check.sh
+          {{- end }}
           {{- end }}
           {{- if .useDockerBuildX }}
           &&

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
     {{- end }}
     {{- end }}
     max_concurrency: {{or .maxConcurrency 10 }}
-    cluster: "prow-presubmits-cluster"
+    cluster: "{{ .cluster }}"
     skip_report: false
     {{- if .extraRefs }}
     extra_refs:
@@ -42,7 +42,7 @@ presubmits:
       timeout: {{ .timeout }}
       {{- end }}
       gcs_configuration:
-        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        bucket: {{ .bucket }}
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     {{- if or .imageBuild .localRegistry .prCreation }}
@@ -58,7 +58,7 @@ presubmits:
       {{- end }}
     {{- end }}
     spec:
-      serviceaccountName: {{ or .serviceAccountName "presubmits-build-account" }}
+      serviceaccountName: {{ .serviceAccountName }}
       automountServiceAccountToken: false
       containers:
       - name: build-container
@@ -69,11 +69,13 @@ presubmits:
         - >
           {{- if .imageBuild }}
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          {{- if not .skipBuldkitCheck }}
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh
           {{- else }}
           scripts/buildkit_check.sh
+          {{- end }}
           {{- end }}
           {{- if .localRegistry }}
           &&

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
         - >
           {{- if .imageBuild }}
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
-          {{- if not .skipBuldkitCheck }}
+          {{- if not .skipBuildkitCheck }}
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Builder-base presubmit is too large to run on fargate. This adds support for running presubmit jobs on the postsubmit cluster. Also, the builder-base job runs off al2 directly instead of the previous builder base, support skipping the buildkit check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
