### PR TITLE
Builder base pre does not need install anymore

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -56,8 +56,6 @@ presubmits:
           &&
           scripts/setup_buildx.sh
           &&
-          ./builder-base/install.sh
-          &&
           make build -C builder-base
         env:
         - name: AL_TAG

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -56,8 +56,6 @@ presubmits:
           &&
           scripts/setup_buildx.sh
           &&
-          ./builder-base/install.sh
-          &&
           make build -C builder-base
         env:
         - name: AL_TAG

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -7,7 +7,6 @@ architecture: AMD64
 cluster: prow-postsubmits-cluster
 automountServiceAccountToken: true
 commands:
-- ./builder-base/install.sh
 - make build -C builder-base
 envVars:
 - name: AL_TAG

--- a/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -7,7 +7,6 @@ architecture: AMD64
 cluster: prow-postsubmits-cluster
 automountServiceAccountToken: true
 commands:
-- ./builder-base/install.sh
 - make build -C builder-base
 envVars:
 - name: AL_TAG


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
