### PR TITLE
Set Fargate profile as env var to identify if running in Fargate

### DIFF
--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -88,6 +88,10 @@ presets:
         fieldPath: metadata.name
   - name: GOPROXY
     value: "http://athens-proxy.default.svc.cluster.local"
+  - name: FARGATE_PROFILE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['eks.amazonaws.com/fargate-profile']
   volumes:
   - name: builder-base-tag-file
     configMap:


### PR DESCRIPTION
Set Fargate profile as env var to identify if running in Fargate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
