### PR TITLE
Removes resource limits from presubmits

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -52,9 +52,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -66,8 +63,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -52,9 +52,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -66,8 +63,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -52,9 +52,6 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -66,8 +63,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -83,6 +83,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -83,6 +83,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -83,9 +83,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -97,9 +94,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -116,8 +110,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-200.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-200.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -81,9 +81,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -95,9 +92,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -114,8 +108,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -85,9 +85,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -99,9 +96,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -118,8 +112,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -85,9 +85,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -99,9 +96,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -118,8 +112,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -52,9 +52,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -66,8 +63,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -57,6 +57,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-presubmits.yaml
@@ -57,6 +57,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-presubmits.yaml
@@ -57,6 +57,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-presubmits.yaml
@@ -57,6 +57,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-presubmits.yaml
@@ -57,6 +57,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -52,9 +52,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -66,8 +63,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -65,6 +65,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -48,6 +48,3 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-20-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/cni-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-20-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-20-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
@@ -57,9 +57,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -71,8 +68,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-20-presubmits.yaml
@@ -59,9 +59,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -73,8 +70,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -59,9 +59,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -73,8 +70,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -59,9 +59,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -73,8 +70,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
@@ -59,9 +59,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -73,8 +70,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
@@ -59,9 +59,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -73,8 +70,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-presubmits.yaml
@@ -64,9 +64,6 @@ presubmits:
           requests:
             memory: "24Gi"
             cpu: "2560m"
-          limits:
-            memory: "24Gi"
-            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -78,9 +75,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -97,8 +91,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro/kubernetes-1-20-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-20-test-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -64,9 +64,6 @@ presubmits:
           requests:
             memory: "24Gi"
             cpu: "2560m"
-          limits:
-            memory: "24Gi"
-            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -78,9 +75,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -97,8 +91,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -64,9 +64,6 @@ presubmits:
           requests:
             memory: "24Gi"
             cpu: "2560m"
-          limits:
-            memory: "24Gi"
-            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -78,9 +75,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -97,8 +91,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -64,9 +64,6 @@ presubmits:
           requests:
             memory: "24Gi"
             cpu: "2560m"
-          limits:
-            memory: "24Gi"
-            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -78,9 +75,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -97,8 +91,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
@@ -64,9 +64,6 @@ presubmits:
           requests:
             memory: "24Gi"
             cpu: "2560m"
-          limits:
-            memory: "24Gi"
-            cpu: "2560m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -78,9 +75,6 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"
       - name: registry
@@ -97,8 +91,5 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"

--- a/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
@@ -49,6 +49,3 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
-          limits:
-            memory: "26Gi"
-            cpu: "3584m"

--- a/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
-          limits:
-            memory: "8Gi"
-            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -46,6 +46,3 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"

--- a/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-20-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
@@ -55,9 +55,6 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
-          limits:
-            memory: "4Gi"
-            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -69,8 +66,5 @@ presubmits:
           runAsGroup: 1000
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1024m"
-          limits:
             memory: "2Gi"
             cpu: "1024m"

--- a/templater/jobs/presubmit/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: true
 commands:
 - make build -C projects/prometheus/alertmanager
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: true
 commands:
 - make build -C projects/aws/amazon-eks-pod-identity-webhook
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/athens-presubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: true
 commands:
 - make build -C projects/gomods/athens
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -3,9 +3,6 @@ runIfChanged: helm-charts/scripts/.*|projects/aws/eks-charts/aws-for-fluent-bit/
 commands:
 - make verify -C projects/aws/eks-charts/aws-for-fluent-bit
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -31,9 +31,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-200.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-200.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -29,9 +29,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -32,9 +32,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -32,9 +32,6 @@ extraRefs:
   org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: true
 commands:
 - make build -C projects/infinityworks/github-exporter
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -3,9 +3,6 @@ runIfChanged: helm-charts/scripts/.*|projects/grafana/helm-charts/.*
 commands:
 - make verify -C projects/grafana/helm-charts
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -3,9 +3,6 @@ runIfChanged: helm-charts/.*
 commands:
 - make verify -C helm-charts
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -3,9 +3,6 @@ runIfChanged: helm-charts/scripts/.*|projects/prometheus-community/helm-charts/.
 commands:
 - make verify -C projects/prometheus-community/helm-charts
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -4,9 +4,6 @@ imageBuild: true
 commands:
 - make build -C projects/prometheus/prometheus
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/aws-iam-authenticator-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/aws-iam-authenticator-1-X-presubmits.yaml
@@ -8,9 +8,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/cni-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/cni-1-X-presubmits.yaml
@@ -6,9 +6,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro/coredns-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/coredns-1-X-presubmits.yaml
@@ -9,9 +9,6 @@ envVars:
 - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
   value: "true"
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/etcd-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/etcd-1-X-presubmits.yaml
@@ -10,9 +10,6 @@ envVars:
 - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
   value: "true"
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/external-attacher-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-attacher-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/external-provisioner-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-provisioner-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/external-resizer-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-resizer-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/livenessprobe-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/livenessprobe-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/main-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/main-presubmits.yaml
@@ -3,9 +3,6 @@ runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^Makefile$|cmd/.*
 commands:
 - make build
 resources:
-  limits:
-    cpu: 1024m
-    memory: 2Gi
   requests:
     cpu: 1024m
     memory: 2Gi

--- a/templater/jobs/presubmit/eks-distro/metrics-server-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/metrics-server-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/jobs/presubmit/eks-distro/node-driver-registrar-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/node-driver-registrar-1-X-presubmits.yaml
@@ -7,9 +7,6 @@ envVars:
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 resources:
-  limits:
-    cpu: 1024m
-    memory: 4Gi
   requests:
     cpu: 1024m
     memory: 4Gi

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -112,11 +112,6 @@ presubmits:
             memory: "{{ .resources.Requests.Memory }}"
             cpu: "{{ .resources.Requests.CPU }}"
           {{- end }}
-          {{- if .resources.Limits }}
-          limits:
-            memory: "{{ .resources.Limits.Memory }}"
-            cpu: "{{ .resources.Limits.CPU }}"
-          {{- end}}
         {{- end }}
         {{- if .volumeMounts }}
         volumeMounts:
@@ -140,9 +135,6 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
-          limits:
-            memory: "2Gi"
-            cpu: "1024m"
       {{- end }}
       {{- if .localRegistry }}
       - name: registry
@@ -159,9 +151,6 @@ presubmits:
           periodSeconds: 3
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "256m"
-          limits:
             memory: "1Gi"
             cpu: "256m"
       {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Based on the docs, fargate looks at the request and since its on its own node the limit does not matter, they implicitly match.  In the case of the builder-base which presubmit now runs on the postsubmit, it actually makes a huge difference since the CPU limit on buildkit restricts it way down.

https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
