### PR TITLE
Fix project path var for k/k presubmits

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -50,13 +50,15 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
         env:
         - name: PROJECT_PATH
+          value: "projects/kubernetes/kubernetes"
+        - name: RELEASE_PROJECT_PATH
           value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
           value: "1-21"

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -50,13 +50,15 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
         env:
         - name: PROJECT_PATH
+          value: "projects/kubernetes/kubernetes"
+        - name: RELEASE_PROJECT_PATH
           value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
           value: "1-22"

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -50,13 +50,15 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
         env:
         - name: PROJECT_PATH
+          value: "projects/kubernetes/kubernetes"
+        - name: RELEASE_PROJECT_PATH
           value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
           value: "1-23"

--- a/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
@@ -50,13 +50,15 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
         env:
         - name: PROJECT_PATH
+          value: "projects/kubernetes/kubernetes"
+        - name: RELEASE_PROJECT_PATH
           value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
           value: "1-24"

--- a/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
@@ -3,11 +3,13 @@ runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernet
 imageBuild: true
 localRegistry: true
 commands:
-- make build clean -C $PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+- make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
 - make build -C $PROJECT_PATH
 - mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
-projectPath: projects/kubernetes/release
+projectPath: projects/kubernetes/kubernetes
 envVars:
+- name: RELEASE_PROJECT_PATH
+  value: projects/kubernetes/release
 - name: RELEASE_BRANCH
   value: {{ .releaseBranch }}
 - name: IMAGE_REPO


### PR DESCRIPTION
There was a [Prowjob refactor](https://github.com/aws/eks-distro-prow-jobs/pull/401) today to modify the Prowjob command from `make -C projects/X/Y` to `make -C $PROJECT_PATH` and set the `PROJECT_PATH` as an env var similar to how we do it in EKS-A Prowjob. This change was a precursor to enable easier templating of EKS-A Prowjobs using the same templating logic we have for EKS-D. In the Kubernetes presubmits, we have two project paths, one to build the images from the kubernetes/release project, followed by building the kubernetes/kubernetes project. In the refactor, we replaced both project paths with `PROJECT_PATH=projects/kubernetes/release` so we weren't calling make build on kubernetes/kubernetes, so we don't have the output directory.
```bash
mv: cannot stat './projects/kubernetes/kubernetes/_output/1-23/*': No such file or directory
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
