### PR TITLE
Changes golang builder to new eks-d golang images

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-ARM64-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.15-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.15/.*"
+    run_if_changed: "projects/golang/go/Makefile|projects/golang/go/1.15/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.16-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.16-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.16/.*"
+    run_if_changed: "projects/golang/go/Makefile|projects/golang/go/1.16/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-ARM64-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.17-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.17-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.17/.*"
+    run_if_changed: "projects/golang/go/Makefile|projects/golang/go/1.17/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.18-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.18-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.18/.*"
+    run_if_changed: "projects/golang/go/Makefile|projects/golang/go/1.18/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-ARM64-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-ARM64-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-PROD-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1.19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1.19-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-distro-build-tooling:
   - name: golang-1.19-tooling-presubmit
     always_run: false
-    run_if_changed: "projects/golang/go/1.19/.*"
+    run_if_changed: "projects/golang/go/Makefile|projects/golang/go/1.19/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
@@ -36,7 +36,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
         command:
         - bash
         - -c

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.15-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.15/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-ARM64-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.15-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.15/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.15-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.15/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.15-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.15-tooling-postsubmit
 runIfChanged: projects/golang/go/1.15/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.16-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.16/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-ARM64-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.16-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.16/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.16-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.16/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.16-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.16-tooling-postsubmit
 runIfChanged: projects/golang/go/1.16/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.17-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.17/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-ARM64-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.17-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.17/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.17-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.17/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.17-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.17-tooling-postsubmit
 runIfChanged: projects/golang/go/1.17/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.18-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.18/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-ARM64-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.18-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.18/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.18-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.18/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.18-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.18-tooling-postsubmit
 runIfChanged: projects/golang/go/1.18/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-ARM64-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.19-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.19/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-ARM64-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.19-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/1.19/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
 architecture: ARM64
 commands:
 - yum -y install make

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-PROD-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.19-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/1.19/RELEASE
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1.19-postsubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.19-tooling-postsubmit
 runIfChanged: projects/golang/go/1.19/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.15-presubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.15-tooling-presubmit
-runIfChanged: projects/golang/go/1.15/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runIfChanged: projects/golang/go/Makefile|projects/golang/go/1.15/.*
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.16-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.16-presubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.16-tooling-presubmit
-runIfChanged: projects/golang/go/1.16/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runIfChanged: projects/golang/go/Makefile|projects/golang/go/1.16/.*
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.17-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.17-presubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.17-tooling-presubmit
-runIfChanged: projects/golang/go/1.17/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runIfChanged: projects/golang/go/Makefile|projects/golang/go/1.17/.*
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.18-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.18-presubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.18-tooling-presubmit
-runIfChanged: projects/golang/go/1.18/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runIfChanged: projects/golang/go/Makefile|projects/golang/go/1.18/.*
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.19-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1.19-presubmits.yaml
@@ -1,6 +1,6 @@
 jobName: golang-1.19-tooling-presubmit
-runIfChanged: projects/golang/go/1.19/.*
-runtimeImage: public.ecr.aws/amazonlinux/amazonlinux:2
+runIfChanged: projects/golang/go/Makefile|projects/golang/go/1.19/.*
+runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will ensure we build golang with the same version from one of our previous builds vs using 1.15 always.

/hold
Holding until I get the new images built and pushed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
