### PR TITLE
Changes minimal images presubmits to not build_deps

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -67,9 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
-          &&
-          if [ ! -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make minimal-images-base-python3.9 -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -79,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -67,9 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-compiler-base ]; then make python-3.9-compiler-images -C $PROJECT_PATH tro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
-          &&
-          if [ ! -f eks-distro-base/Dockerfile.minimal-base-compiler-base ]; then make minimal-images-base-python3.9 -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:
@@ -79,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-golang ]; then make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -13,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -5,8 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
-- if [ ! -f eks-distro-base/Dockerfile.minimal-base-compiler ]; then make minimal-images-base-python3.9 -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -14,8 +13,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -5,8 +5,7 @@ localRegistry: true
 useDockerBuildX: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-compiler-base ]; then make python-3.9-compiler-images -C $PROJECT_PATH tro-base IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
-- if [ ! -f eks-distro-base/Dockerfile.minimal-base-compiler-base ]; then make minimal-images-base-python3.9 -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:
@@ -14,8 +13,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 - name: PRUNE_BUILDCTL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Building deps in presubmit does not actually match the main building workflows for these images. Instead we tend to build new images via the periodic which only builds what it needs. This changes all the builds, except for iptables, to use the previously built base images instead of building the entire stack in every build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
