### PR TITLE
Uses minimal builder image for distro base images

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -55,7 +55,7 @@ periodics:
       arch: AMD64
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -55,7 +55,7 @@ periodics:
       arch: AMD64
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -58,7 +58,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -58,7 +58,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -77,8 +77,6 @@ presubmits:
           value: "2022"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -77,8 +77,6 @@ presubmits:
           value: "2"
         - name: IMAGE_REPO
           value: "localhost:5000"
-        - name: BUILD_DEPS
-          value: "true"
         - name: PLATFORMS
           value: "linux/amd64"
         - name: BUILDKITD_IMAGE

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -52,7 +52,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 prCreation: true
 architecture: AMD64
 useDockerBuildX: true
+useMinimalBuilderBase: true
 automountServiceAccountToken: true
 serviceAccountName: postsubmits-build-account
 commands:

--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 prCreation: true
 architecture: AMD64
 useDockerBuildX: true
+useMinimalBuilderBase: true
 automountServiceAccountToken: true
 serviceAccountName: postsubmits-build-account
 commands:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 prCreation: true
 architecture: AMD64
 useDockerBuildX: true
+useMinimalBuilderBase: true
 automountServiceAccountToken: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 prCreation: true
 architecture: AMD64
 useDockerBuildX: true
+useMinimalBuilderBase: true
 automountServiceAccountToken: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
@@ -13,8 +14,6 @@ envVars:
   value: 2022
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make compiler-base-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
@@ -13,8 +14,6 @@ envVars:
   value: 2
 - name: IMAGE_REPO
   value: localhost:5000
-- name: BUILD_DEPS
-  value: true
 - name: PLATFORMS
   value: linux/amd64
 extraRefs:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-csi -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-csi-ebs -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-csi-ebs -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-csi -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-docker-client -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-docker-client -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-git -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-git -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.15-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.18-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-1.19-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-haproxy -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-haproxy -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-iptables -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-iptables -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - if [ -f eks-distro-base/Dockerfile.minimal-base-java ]; then make java-17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - if [ -f eks-distro-base/Dockerfile.minimal-base-java ]; then make java-17-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-kind -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-kind -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-nginx -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-nginx -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-nsenter -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make minimal-images-base-nsenter -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -3,6 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
+useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make python-3.9-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}

--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -55,6 +55,7 @@ type JobConfig struct {
 	Timeout                      string         `json:"timeout,omitempty"`
 	ImageBuild                   bool           `json:"imageBuild,omitempty"`
 	UseDockerBuildX              bool           `json:"useDockerBuildX,omitempty"`
+	UseMinimalBuilderBase        bool           `json:"useMinimalBuilderBase,omitempty"`
 	PRCreation                   bool           `json:"prCreation,omitempty"`
 	RuntimeImage                 string         `json:"runtimeImage,omitempty"`
 	LocalRegistry                bool           `json:"localRegistry,omitempty"`

--- a/templater/main.go
+++ b/templater/main.go
@@ -71,6 +71,11 @@ func main() {
 					envVars = append(envVars, &types.EnvVar{Name: "USE_BUILDX", Value: "true"})
 				}
 
+				templateBuilderBaseTag := builderBaseTag
+				if jobConfig.UseMinimalBuilderBase {
+					templateBuilderBaseTag = strings.Replace(builderBaseTag, "standard", "minimal", 1)
+				}
+
 				branches := jobConfig.Branches
 				if jobType == "postsubmit" && len(branches) == 0 {
 					branches = append(branches, "^main$")
@@ -96,7 +101,7 @@ func main() {
 					"localRegistry":                jobConfig.LocalRegistry,
 					"serviceAccountName":           serviceAccountName,
 					"command":                      strings.Join(jobConfig.Commands, "\n&&\n"),
-					"builderBaseTag":               builderBaseTag,
+					"builderBaseTag":               templateBuilderBaseTag,
 					"buildkitImageTag":             buildkitImageTag,
 					"resources":                    jobConfig.Resources,
 					"envVars":                      envVars,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The minimal builder image does not include all the go versions and ends up being just over 1gb instead of over 4.  For these image builds we do not need go so the minimal image should be usable and give us some breathing room space wise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
