### PR TITLE
add bucket in jobConfig to use in eks-A templater

### DIFF
--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -68,5 +68,6 @@ type JobConfig struct {
 	Volumes                      []*Volume      `json:"volumes,omitempty"`
 	AutomountServiceAccountToken string         `json:"automountServiceAccountToken,omitempty"`
 	Cluster                      string         `json:"cluster,omitempty"`
+	Bucket                       string         `json:"bucket,omitempty"`
 	ProjectPath                  string         `json:"projectPath,omitempty"`
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EKS-A prow jobs has some prow jobs which needs to be configured in minimal config thus adding bucket in the types.go jobConfig struct. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
