### PR TITLE
Removes buildctl prune from distro presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -79,8 +79,6 @@ presubmits:
           value: "localhost:5000"
         - name: PLATFORMS
           value: "linux/amd64"
-        - name: PRUNE_BUILDCTL
-          value: "true"
         - name: BUILDKITD_IMAGE
           value: "moby/buildkit:v0.10.5-rootless"
         - name: USE_BUILDX

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: true
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -16,8 +16,6 @@ envVars:
   value: localhost:5000
 - name: PLATFORMS
   value: linux/amd64
-- name: PRUNE_BUILDCTL
-  value: "true"
 extraRefs:
 - baseRef: main
   org: eks-distro-pr-bot


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Now that these are running on the minimal builder we do not need the prune.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
