### PR TITLE
Run the base nodejs build before compiler in presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make minimal-images-base-nodejs-16 nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -67,7 +67,7 @@ presubmits:
           &&
           export DATE_EPOCH=$(date "+%F-%s")
           &&
-          if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+          if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make minimal-images-base-nodejs-16 nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
           &&
           make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
         env:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -6,7 +6,7 @@ useDockerBuildX: true
 useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make minimal-images-base-nodejs-16 nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -6,7 +6,7 @@ useDockerBuildX: true
 useMinimalBuilderBase: true
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
-- if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
+- if [ -f eks-distro-base/Dockerfile.minimal-base-nodejs ]; then make minimal-images-base-nodejs-16 nodejs-16-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}; fi
 - make create-pr -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}
 projectPath: eks-distro-base
 envVars:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The layer which contains the nodejs runtime/compiler is meant to be shared between the runtime image and the compiler images. This makes the presubmit build the nodejs runtime image first then builds the compiler images, which matches what would happen in a periodic update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
