### PR TITLE
Add image build to golang jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: ARM64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -66,6 +72,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -73,3 +85,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -69,3 +75,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -64,6 +70,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -71,3 +83,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -67,3 +73,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -41,6 +43,10 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -59,3 +65,16 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: ARM64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -66,6 +72,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -73,3 +85,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -69,3 +75,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -64,6 +70,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -71,3 +83,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -67,3 +73,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -41,6 +43,10 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -59,3 +65,16 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: ARM64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -66,6 +72,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -73,3 +85,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -69,3 +75,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -64,6 +70,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -71,3 +83,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -67,3 +73,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -41,6 +43,10 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -59,3 +65,16 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: ARM64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -66,6 +72,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -73,3 +85,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -69,3 +75,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -64,6 +70,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -71,3 +83,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -67,3 +73,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -41,6 +43,10 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -59,3 +65,16 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: ARM64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -66,6 +72,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -73,3 +85,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -69,3 +75,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
@@ -34,9 +34,11 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: release-build-account
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64
       containers:
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -64,6 +70,12 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"
@@ -71,3 +83,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,10 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -67,3 +73,16 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -41,6 +43,10 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          scripts/buildkit_check.sh
+          &&
           yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
@@ -59,3 +65,16 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
@@ -2,6 +2,8 @@ jobName: golang-{{ .jobGoVersion }}-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/RELEASE
 runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 architecture: ARM64
+imageBuild: true
+automountServiceAccountToken: true
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH
@@ -25,6 +27,12 @@ envVars:
     value: ARM64
   - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
     value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+  - name: IMAGE_REPO
+    value: public.ecr.aws/eks-distro-build-tooling
+  - name: ECR_PUBLIC_PUSH_ROLE_ARN
+    value: arn:aws:iam::832188789588:role/ECRPublicPushRole
   - name: AWS_REGION
     value: us-east-1
 serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-postsubmits.yaml
@@ -2,6 +2,7 @@ jobName: golang-{{ .jobGoVersion }}-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/.*
 runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 architecture: ARM64
+imageBuild: true
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
@@ -1,6 +1,8 @@
 jobName: golang-{{ .jobGoVersion }}-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/RELEASE
 runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
+imageBuild: true
+automountServiceAccountToken: true
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH
@@ -22,6 +24,12 @@ envVars:
     value: artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2
   - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
     value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+  - name: AWS_REGION
+    value: us-east-1
+  - name: IMAGE_REPO
+    value: public.ecr.aws/eks-distro-build-tooling
+  - name: ECR_PUBLIC_PUSH_ROLE_ARN
+    value: arn:aws:iam::832188789588:role/ECRPublicPushRole
   - name: AWS_REGION
     value: us-east-1
 serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-postsubmits.yaml
@@ -1,6 +1,7 @@
 jobName: golang-{{ .jobGoVersion }}-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/.*
 runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
+imageBuild: true
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
@@ -1,6 +1,7 @@
 jobName: golang-{{ .jobGoVersion }}-tooling-presubmit
 runIfChanged: projects/golang/go/Makefile|projects/golang/go/{{ .golangVersion }}/.*
 runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
+imageBuild: true
 commands:
 - yum -y install make
 - make install-deps -C $PROJECT_PATH


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The EKS Go builds will now also build a debian-based Golang image; prod jobs will push that image to public ECR. This add image builds to the EKS Go prow jobs, and adds the image push configuration for the prod public ECR to the prod post-submits.

Shoutout to @zafs23 for making it super easy to modify the EKS Go prow jobs w/https://github.com/aws/eks-distro-prow-jobs/pull/419

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
