### PR TITLE
update prod post-submits to not duplicate AWS_REGION env var for golang

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
@@ -76,8 +76,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
@@ -74,8 +74,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
@@ -76,8 +76,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
@@ -74,8 +74,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
@@ -76,8 +76,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
@@ -74,8 +74,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
@@ -76,8 +76,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
@@ -74,8 +74,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
@@ -76,8 +76,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
@@ -74,8 +74,6 @@ postsubmits:
           value: "public.ecr.aws/eks-distro-build-tooling"
         - name: ECR_PUBLIC_PUSH_ROLE_ARN
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
-        - name: AWS_REGION
-          value: "us-east-1"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
@@ -33,6 +33,4 @@ envVars:
     value: public.ecr.aws/eks-distro-build-tooling
   - name: ECR_PUBLIC_PUSH_ROLE_ARN
     value: arn:aws:iam::832188789588:role/ECRPublicPushRole
-  - name: AWS_REGION
-    value: us-east-1
 serviceAccountName: release-build-account

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
@@ -30,6 +30,4 @@ envVars:
     value: public.ecr.aws/eks-distro-build-tooling
   - name: ECR_PUBLIC_PUSH_ROLE_ARN
     value: arn:aws:iam::832188789588:role/ECRPublicPushRole
-  - name: AWS_REGION
-    value: us-east-1
 serviceAccountName: release-build-account


### PR DESCRIPTION
update golang prod post-submits with fixed template

*Issue #, if available:*

*Description of changes:*
duplicated AWS_REGION in the prod post submits; remove the dupe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
