### PR TITLE
Use builder base for go prow jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
@@ -47,8 +47,6 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          yum -y install make
-          &&
           make install-deps -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
@@ -47,8 +47,6 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          yum -y install make
-          &&
           make install-deps -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
@@ -47,8 +47,6 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          yum -y install make
-          &&
           make install-deps -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
@@ -47,8 +47,6 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          yum -y install make
-          &&
           make install-deps -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
@@ -47,8 +47,6 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          yum -y install make
-          &&
           make install-deps -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
@@ -1,6 +1,5 @@
 jobName: golang-{{ .jobGoVersion }}-tooling-presubmit
 runIfChanged: projects/golang/go/Makefile|projects/golang/go/{{ .golangVersion }}/.*
-runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 imageBuild: true
 commands:
 - yum -y install make

--- a/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/golang-1-X-presubmits.yaml
@@ -2,7 +2,6 @@ jobName: golang-{{ .jobGoVersion }}-tooling-presubmit
 runIfChanged: projects/golang/go/Makefile|projects/golang/go/{{ .golangVersion }}/.*
 imageBuild: true
 commands:
-- yum -y install make
 - make install-deps -C $PROJECT_PATH
 - make build -C $PROJECT_PATH
 projectPath: projects/golang/go


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we don't need to install make in the prow job now that we're using the builder base

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
