### PR TITLE
Adds clean/clean-go-cache in presubmit jobs

### DIFF
--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
@@ -50,9 +50,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
@@ -50,9 +50,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
@@ -50,9 +50,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
@@ -50,9 +50,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
@@ -50,6 +50,8 @@ presubmits:
           make build -C $PROJECT_PATH
           &&
           mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -50,11 +50,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -50,11 +50,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -50,11 +50,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
@@ -50,11 +50,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
           &&
           make build -C $PROJECT_PATH
           &&
           mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build images -C $PROJECT_PATH
+          make build clean-go-cache clean images -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/templater/jobs/presubmit/eks-distro/aws-cloud-controller-manager-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/aws-cloud-controller-manager-1-X-presubmits.yaml
@@ -3,8 +3,8 @@ runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/
 imageBuild: true
 localRegistry: true
 commands:
-- make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes/cloud-provider-aws
 envVars:
 - name: RELEASE_PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro/aws-iam-authenticator-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/aws-iam-authenticator-1-X-presubmits.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 commands:
 - make build -C $PROJECT_PATH
 - mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+- make clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-sigs/aws-iam-authenticator
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/cni-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/cni-1-X-presubmits.yaml
@@ -1,7 +1,7 @@
 jobName: cni-plugins-{{ .releaseBranch }}-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/containernetworking/plugins/(build|Makefile|{{ .releaseBranch }})
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/containernetworking/plugins
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/coredns-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/coredns-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: coredns-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/coredns/coredns/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/coredns/coredns
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/etcd-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/etcd-1-X-presubmits.yaml
@@ -4,6 +4,7 @@ imageBuild: true
 commands:
 - make build -C $PROJECT_PATH
 - mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+- make clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/etcd-io/etcd
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/external-attacher-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-attacher-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: external-attacher-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-attacher/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/external-attacher
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/external-provisioner-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-provisioner-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: external-provisioner-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-provisioner/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/external-provisioner
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/external-resizer-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-resizer-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: external-resizer-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-resizer/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/external-resizer
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/external-snapshotter-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/external-snapshotter-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: external-snapshotter-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-snapshotter/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/external-snapshotter
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/kubernetes-1-X-presubmits.yaml
@@ -3,9 +3,10 @@ runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_IPTABLES_
 imageBuild: true
 localRegistry: true
 commands:
-- make build clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+- make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
 - make build -C $PROJECT_PATH
 - mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+- make clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes/kubernetes
 envVars:
 - name: RELEASE_PROJECT_PATH

--- a/templater/jobs/presubmit/eks-distro/kubernetes-release-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/kubernetes-release-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: kubernetes-release-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/release/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes/release
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/livenessprobe-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/livenessprobe-1-X-presubmits.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 cluster: prow-postsubmits-cluster
 architecture: AMD64
 commands:
-- make build images -C $PROJECT_PATH
+- make build clean-go-cache clean images -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/livenessprobe
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/metrics-server-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/metrics-server-1-X-presubmits.yaml
@@ -2,7 +2,7 @@ jobName: metrics-server-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/metrics-server/(build|docker|Makefile|{{ .releaseBranch }})
 imageBuild: true
 commands:
-- make build -C $PROJECT_PATH
+- make build clean-go-cache clean -C $PROJECT_PATH
 projectPath: projects/kubernetes-sigs/metrics-server
 envVars:
 - name: RELEASE_BRANCH

--- a/templater/jobs/presubmit/eks-distro/node-driver-registrar-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/node-driver-registrar-1-X-presubmits.yaml
@@ -5,7 +5,7 @@ localRegistry: true
 cluster: prow-postsubmits-cluster
 architecture: AMD64
 commands:
-- make build images -C $PROJECT_PATH
+- make build clean-go-cache clean images -C $PROJECT_PATH
 projectPath: projects/kubernetes-csi/node-driver-registrar
 envVars:
 - name: RELEASE_BRANCH


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To validate the clean and clean-go-cache methods I'd like to run them as part of the presubmit job, even tho by this point in the job space doesnt really matter.  The alternative was to add it to the Common.mk but this affects the ability to add targets in project specific makefiles that depend on things in _output.  This feels safer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
