### PR TITLE
use builder-base for golang post-submits

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.15-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.16-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.17-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.18-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: ARM64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
         arch: AMD64
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/golang:1.19-gcc-al2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-8026816b32209021fe189380fb51e25690f08d37.2
         command:
         - bash
         - -c
@@ -51,8 +51,6 @@ postsubmits:
           trap 'touch /status/done' EXIT
           &&
           scripts/buildkit_check.sh
-          &&
-          yum -y install make
           &&
           make install-deps -C $PROJECT_PATH
           &&

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-PROD-postsubmits.yaml
@@ -1,11 +1,9 @@
 jobName: golang-{{ .jobGoVersion }}-ARM64-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/RELEASE
-runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 architecture: ARM64
 imageBuild: true
 automountServiceAccountToken: true
 commands:
-- yum -y install make
 - make install-deps -C $PROJECT_PATH
 - projects/golang/go/scripts/prow_release.sh
 projectPath: projects/golang/go

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-ARM64-postsubmits.yaml
@@ -1,10 +1,8 @@
 jobName: golang-{{ .jobGoVersion }}-ARM64-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/.*
-runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 architecture: ARM64
 imageBuild: true
 commands:
-- yum -y install make
 - make install-deps -C $PROJECT_PATH
 - make release -C $PROJECT_PATH
 projectPath: projects/golang/go

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
@@ -1,10 +1,8 @@
 jobName: golang-{{ .jobGoVersion }}-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/RELEASE
-runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 imageBuild: true
 automountServiceAccountToken: true
 commands:
-- yum -y install make
 - make install-deps -C $PROJECT_PATH
 - projects/golang/go/scripts/prow_release.sh
 projectPath: projects/golang/go

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-postsubmits.yaml
@@ -1,9 +1,7 @@
 jobName: golang-{{ .jobGoVersion }}-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/.*
-runtimeImage: public.ecr.aws/eks-distro-build-tooling/golang:{{ .golangVersion }}-gcc-al2
 imageBuild: true
 commands:
-- yum -y install make
 - make install-deps -C $PROJECT_PATH
 - make release -C $PROJECT_PATH
 projectPath: projects/golang/go


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use the builder-base for the Golang post-submits so that we can execute the image build for the `golang-debian` image. 

see https://github.com/aws/eks-distro-build-tooling/pull/667

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
