### PR TITLE
Adds disk usage sidecar to presubmit jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -40,6 +40,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -85,3 +86,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -40,6 +40,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -85,3 +86,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-make-tests.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-make-tests.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -118,3 +119,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -118,3 +119,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -47,6 +47,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -116,3 +117,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "release"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -37,6 +37,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -68,3 +69,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -53,3 +53,9 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "2048m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -95,3 +96,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -95,3 +96,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -95,3 +96,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -95,3 +96,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -74,3 +75,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -74,3 +75,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -74,3 +75,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -74,3 +75,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -72,3 +73,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -72,3 +73,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -72,3 +73,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -72,3 +73,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
@@ -47,3 +47,9 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "docs"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -76,3 +77,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -99,3 +100,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -99,3 +100,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -99,3 +100,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -99,3 +100,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
@@ -51,3 +51,9 @@ presubmits:
           requests:
             memory: "26Gi"
             cpu: "3584m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -49,3 +49,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
@@ -70,3 +71,9 @@ presubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
@@ -34,6 +34,7 @@ presubmits:
     labels:
       image-build: "true"
       local-registry: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -93,3 +94,9 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -37,12 +37,35 @@ presets:
   - name: registry-entrypoint
     readOnly: false
     mountPath: /registry-script
+  - name: docker-registry-data
+    readOnly: false
+    mountPath: /var/lib/registry
   volumes:
   - name: registry-entrypoint
     configMap:
       name: registry-entrypoint
       items:
       - key: registry-entrypoint.sh
+        path: entrypoint.sh
+  - name: docker-registry-data
+    emptyDir: {}
+- labels:
+    disk-usage: "true"
+  volumeMounts:
+  - name: go-build-cache
+    readOnly: false
+    mountPath: /root/.cache/go-build
+  - name: disk-usage-entrypoint
+    readOnly: false
+    mountPath: /disk-usage-script
+  volumes:
+  - name: go-build-cache
+    emptyDir: {}
+  - name: disk-usage-entrypoint
+    configMap:
+      name: disk-usage-entrypoint
+      items:
+      - key: disk-usage-entrypoint.sh
         path: entrypoint.sh
 - labels:
     image-build: "true"
@@ -62,6 +85,9 @@ presets:
   - name: status
     readOnly: false
     mountPath: /status
+  - name: buildkitd-data
+    readOnly: false
+    mountPath: /home/user/.local/share/buildkit    
   volumes:
   # The files in this repo update the respective configmaps
   # via the config-updater plugin in plugins.yaml for hook
@@ -80,6 +106,8 @@ presets:
   - name: run-buildkit
     emptyDir: {}
   - name: status
+    emptyDir: {}
+  - name: buildkitd-data
     emptyDir: {}
 - env:
   - name: AWS_ROLE_SESSION_NAME

--- a/scripts/disk-usage-entrypoint.sh
+++ b/scripts/disk-usage-entrypoint.sh
@@ -21,15 +21,15 @@ while [ ! -f /status/done ]; do
     
     for folder in "/root/.cache/go-build" "/home/prow/go/pkg/mod" "/home/user/.local/share/buildkit" "/var/lib/registry" "/tmp"; do
         if [ -d $folder ]; then
-            du -sh $folder
+            du -sh $folder 2> /dev/null
         fi
     done
 
     for folder in "/home/prow/go/src/github.com/aws"; do
         if [ -d $folder ]; then
             echo -e "\n--------------- $folder -------------------"
-            du -Sh $folder | sort -rh | head -10
-            du -sh $folder
+            du -Sh $folder 2> /dev/null | sort -rh | head -10 
+            du -sh $folder 2> /dev/null
             echo -e "--------------- $folder -------------------\n"
         fi
     done

--- a/scripts/disk-usage-entrypoint.sh
+++ b/scripts/disk-usage-entrypoint.sh
@@ -1,0 +1,41 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run registry in background mode to be able to poll
+# for the done status file and kill process after
+
+
+while [ ! -f /status/done ]; do
+    echo -e "-------------------------------------------------------------------------------------------------"
+    
+    for folder in "/root/.cache/go-build" "/home/prow/go/pkg/mod" "/home/user/.local/share/buildkit" "/var/lib/registry" "/tmp"; do
+        if [ -d $folder ]; then
+            du -sh $folder
+        fi
+    done
+
+    for folder in "/home/prow/go/src/github.com/aws"; do
+        if [ -d $folder ]; then
+            echo -e "\n--------------- $folder -------------------"
+            du -Sh $folder | sort -rh | head -10
+            du -sh $folder
+            echo -e "--------------- $folder -------------------\n"
+        fi
+    done
+
+    df -h
+    echo -e "-------------------------------------------------------------------------------------------------\n"
+    
+    sleep 20
+done

--- a/templater/main.go
+++ b/templater/main.go
@@ -112,6 +112,7 @@ func main() {
 					"cluster":                      cluster,
 					"bucket":                       bucket,
 					"projectPath":                  jobConfig.ProjectPath,
+					"diskUsage":                    true,
 				}
 
 				err := GenerateProwjob(fileName, template, data)

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -56,6 +56,9 @@ presubmits:
       {{- if .prCreation }}
       pr-creation: "true"
       {{- end }}
+      {{- if .diskUsage }}
+      disk-usage: "true"
+      {{- end}}
     {{- end }}
     spec:
       serviceaccountName: {{ .serviceAccountName }}
@@ -155,6 +158,14 @@ presubmits:
           requests:
             memory: "1Gi"
             cpu: "256m"
+      {{- end }}
+      {{- if .diskUsage }}
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor
       {{- end }}
       {{- if .volumes }}
       volumes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We from time to time run out of disk space both in fargate runs (presubmits) and postsubmit runs.  When debugging these cases I usually attach to a running job and basically run a simple disk usage script in the background.  This adds a sidecar to all presubmits, will add to postsubmits in a follow up, which just logs out current disk usage across key folders.  This could be helpful when debugging these cases where pods are evicted due to disk space.

Helm chart chage: https://github.com/aws/eks-distro-build-tooling/pull/692

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
