### PR TITLE
Fixes status/done handling for non-image builds

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make verify -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-make-tests.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-make-tests.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           if [ -f eks-distro-base/make-tests/make-dry-run ]; then make run-make-tests -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-release-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make test -C $PROJECT_PATH
           &&
           make build -C $PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make verify -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make verify -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build -C $PROJECT_PATH ARTIFACTS_BUCKET="eks-d-postsubmit-artifacts"
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make verify -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make verify-prowjobs -C $PROJECT_PATH
           &&
           make lint -C $LINT_PROJECT_PATH

--- a/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-21-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-22-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-24-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build -C $PROJECT_PATH
           &&
           mv ./docs/site/* /logs/artifacts

--- a/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-test-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make test -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-test-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make test -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make test -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-test-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make test -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           make build
         env:
         - name: PROJECT_PATH

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -74,8 +74,8 @@ presubmits:
         - bash
         - -c
         - >
-          {{- if .imageBuild }}
           trap '{{- if .useDockerBuildX }}(docker buildx rm eks-d-builders || true) && {{ end }}touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          {{- if .imageBuild }}
           &&
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For nonimage builds we werent creating the status/done file. This is now needed for the disk-usage sidecar

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
