### PR TITLE
Remove disk-usage from jobs without image-build

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits-2022.yaml
@@ -82,10 +82,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-presubmits.yaml
@@ -82,10 +82,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-15.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-16.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-17.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-18.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-19.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-2022.yaml
@@ -99,10 +99,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -115,10 +111,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables.yaml
@@ -99,10 +99,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -115,10 +111,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9-2022.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3.9.yaml
@@ -97,10 +97,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -113,10 +109,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
@@ -95,10 +95,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -111,10 +107,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-presubmits.yaml
@@ -65,10 +65,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-21-presubmits.yaml
@@ -76,10 +76,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -92,10 +88,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-22-presubmits.yaml
@@ -76,10 +76,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -92,10 +88,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
@@ -76,10 +76,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -92,10 +88,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-24-presubmits.yaml
@@ -76,10 +76,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -92,10 +88,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-21-presubmits.yaml
@@ -71,10 +71,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-22-presubmits.yaml
@@ -71,10 +71,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
@@ -71,10 +71,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-24-presubmits.yaml
@@ -71,10 +71,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-21-presubmits.yaml
@@ -69,10 +69,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-22-presubmits.yaml
@@ -69,10 +69,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
@@ -69,10 +69,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-24-presubmits.yaml
@@ -69,10 +69,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-21-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-22-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-24-presubmits.yaml
@@ -73,10 +73,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-21-presubmits.yaml
@@ -80,10 +80,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -96,10 +92,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-22-presubmits.yaml
@@ -80,10 +80,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -96,10 +92,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -80,10 +80,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -96,10 +92,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-24-presubmits.yaml
@@ -80,10 +80,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -96,10 +92,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-21-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-22-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-24-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-21-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-22-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-24-presubmits.yaml
@@ -67,10 +67,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-21-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-22-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-24-presubmits.yaml
@@ -74,10 +74,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - name: registry
         image: public.ecr.aws/docker/library/registry:2
         command:
@@ -90,10 +86,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       - command:
         - sh
         args:

--- a/jobs/presets.yaml
+++ b/jobs/presets.yaml
@@ -82,9 +82,6 @@ presets:
   - name: entrypoint
     readOnly: false
     mountPath: /script
-  - name: status
-    readOnly: false
-    mountPath: /status
   - name: buildkitd-data
     readOnly: false
     mountPath: /home/user/.local/share/buildkit    
@@ -104,8 +101,6 @@ presets:
       - key: buildkitd-entrypoint.sh
         path: entrypoint.sh
   - name: run-buildkit
-    emptyDir: {}
-  - name: status
     emptyDir: {}
   - name: buildkitd-data
     emptyDir: {}
@@ -127,7 +122,12 @@ presets:
       items:
       - key: BUILDER_BASE_TAG_FILE
         path: BUILDER_BASE_TAG_FILE
+  - name: status
+    emptyDir: {}
   volumeMounts:
   - name: builder-base-tag-file
     readOnly: false
     mountPath: /config
+  - name: status
+    readOnly: false
+    mountPath: /status

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -136,10 +136,6 @@ presubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       {{- end }}
       {{- if .localRegistry }}
       - name: registry
@@ -154,10 +150,6 @@ presubmits:
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 3
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "256m"
       {{- end }}
       {{- if .diskUsage }}
       - command:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Move /status mount to all jobs instead of under image-build

We also recently remove the requests for the sidecars in all on eks-a because they are not needed, making this change as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
