### PR TITLE
Reduce go image resources

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-images-postsubmits.yaml
@@ -68,11 +68,8 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"
+            memory: "2Gi"
+            cpu: "1"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-images-postsubmits.yaml
@@ -68,11 +68,8 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"
+            memory: "2Gi"
+            cpu: "1"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-images-postsubmits.yaml
@@ -68,11 +68,8 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"
+            memory: "2Gi"
+            cpu: "1"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-images-postsubmits.yaml
@@ -68,11 +68,8 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"
+            memory: "2Gi"
+            cpu: "1"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
@@ -68,11 +68,8 @@ postsubmits:
           value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
-            memory: "16Gi"
-            cpu: "2560m"
-          limits:
-            memory: "16Gi"
-            cpu: "2560m"
+            memory: "2Gi"
+            cpu: "1"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-images-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-images-postsubmits.yaml
@@ -7,12 +7,9 @@ commands:
 - projects/golang/go/scripts/prow_release_images.sh
 projectPath: projects/golang/go
 resources:
-  limits:
-    cpu: 2560m
-    memory: 16Gi
   requests:
-    cpu: 2560m
-    memory: 16Gi
+    cpu: "1"
+    memory: 2Gi
 envVars:
   - name: GO_SOURCE_VERSION
     value: {{ .golangVersion }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we don't need 16Gi to build these images. Mirroring the builder-base post-submit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
