### PR TITLE
Add duplicate job name check in linter

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-test-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-test-presubmits.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-distro-build-tooling:
-  - name: eks-distro-base-make-tests
+  - name: eks-distro-base-test-presubmit
     always_run: false
     run_if_changed: "eks-distro-base/.*"
     max_concurrency: 10

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-test-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-test-presubmits.yaml
@@ -1,4 +1,4 @@
-jobName: eks-distro-base-make-tests
+jobName: eks-distro-base-test-presubmit
 runIfChanged: eks-distro-base/.*
 commands:
 - if [ -f eks-distro-base/make-tests/make-dry-run ]; then make run-make-tests -C $PROJECT_PATH; fi


### PR DESCRIPTION
Add a check function to the Prow linter that checks whether job names have been duplicated in the latest changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
