### PR TITLE
Adds disk-usage build sidecar to postsubmit/periodics

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/alertmanager-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -69,3 +70,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -69,3 +70,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
@@ -69,3 +70,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/aws-for-fluent-bit-helm-chart-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
@@ -46,7 +48,15 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/aws/eks-charts/aws-for-fluent-bit"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits-2022.yaml
@@ -44,6 +44,7 @@ postsubmits:
     labels:
       image-build: "true"
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -99,3 +100,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/builder-base-postsubmits.yaml
@@ -44,6 +44,7 @@ postsubmits:
     labels:
       image-build: "true"
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -99,3 +100,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-2022.yaml
@@ -48,6 +48,7 @@ periodics:
   labels:
     image-build: "true"
     pr-creation: "true"
+    disk-usage: "true"
   spec:
     serviceaccountName: postsubmits-build-account
     automountServiceAccountToken: true
@@ -107,3 +108,9 @@ periodics:
         requests:
           memory: "2Gi"
           cpu: "1024m"
+    - command:
+      - sh
+      args:
+      - /disk-usage-script/entrypoint.sh
+      image: public.ecr.aws/amazonlinux/amazonlinux:2
+      name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -48,6 +48,7 @@ periodics:
   labels:
     image-build: "true"
     pr-creation: "true"
+    disk-usage: "true"
   spec:
     serviceaccountName: postsubmits-build-account
     automountServiceAccountToken: true
@@ -107,3 +108,9 @@ periodics:
         requests:
           memory: "2Gi"
           cpu: "1024m"
+    - command:
+      - sh
+      args:
+      - /disk-usage-script/entrypoint.sh
+      image: public.ecr.aws/amazonlinux/amazonlinux:2
+      name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-2022.yaml
@@ -51,6 +51,7 @@ postsubmits:
     labels:
       image-build: "true"
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -112,3 +113,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -51,6 +51,7 @@ postsubmits:
     labels:
       image-build: "true"
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -112,3 +113,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -49,6 +49,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -61,9 +62,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make update-base-image-other-repos -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "eks-distro-base"
         - name: AWS_REGION
           value: "us-east-1"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -69,3 +70,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-PROD-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -94,3 +95,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-ARM64-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-images-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -83,3 +84,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make install-deps -C $PROJECT_PATH
           &&
           projects/golang/go/scripts/prow_release.sh
@@ -69,3 +73,9 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -84,3 +85,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-PROD-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -94,3 +95,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-ARM64-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-images-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -83,3 +84,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make install-deps -C $PROJECT_PATH
           &&
           projects/golang/go/scripts/prow_release.sh
@@ -69,3 +73,9 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -84,3 +85,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-PROD-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -94,3 +95,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-ARM64-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-images-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -83,3 +84,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make install-deps -C $PROJECT_PATH
           &&
           projects/golang/go/scripts/prow_release.sh
@@ -69,3 +73,9 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -84,3 +85,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-PROD-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -94,3 +95,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-ARM64-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-images-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -83,3 +84,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make install-deps -C $PROJECT_PATH
           &&
           projects/golang/go/scripts/prow_release.sh
@@ -69,3 +73,9 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -84,3 +85,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-PROD-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -94,3 +95,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-ARM64-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: true
@@ -83,3 +84,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: true
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make install-deps -C $PROJECT_PATH
           &&
           projects/golang/go/scripts/prow_release.sh
@@ -69,3 +73,9 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -84,3 +85,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/grafana-helm-chart-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
@@ -46,7 +48,15 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/grafana/helm-charts"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
@@ -46,7 +48,15 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "helm-charts"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH ARTIFACTS_BUCKET="eks-d-postsubmit-artifacts"
         env:
         - name: PROJECT_PATH
@@ -54,3 +58,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: charts-build-account
       automountServiceAccountToken: false
@@ -46,7 +48,15 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/prometheus-community/helm-charts"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -69,3 +70,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-deck-postsubmits.yaml
@@ -41,6 +41,7 @@ postsubmits:
     labels:
       image-build: "true"
       pr-creation: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/announcement-postsubmits.yaml
+++ b/jobs/aws/eks-distro/announcement-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -46,6 +48,8 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           ./release/prow-announce.sh
         env:
         - name: PROJECT_PATH
@@ -56,3 +60,9 @@ postsubmits:
           value: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
         - name: AWS_REGION
           value: "us-east-1"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-21-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -92,3 +93,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-22-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -92,3 +93,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -92,3 +93,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -92,3 +93,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -92,3 +93,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-21-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -82,3 +83,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-22-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -82,3 +83,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -82,3 +83,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/dev-release-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-24-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -82,3 +83,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/dev-release-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-25-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
@@ -82,3 +83,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
+++ b/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
@@ -35,6 +35,7 @@ periodics:
     s3_credentials_secret: s3-credentials
   labels:
     pr-creation: "true"
+    disk-usage: "true"
   spec:
     serviceaccountName: periodics-build-account
     automountServiceAccountToken: false
@@ -47,6 +48,8 @@ periodics:
       - bash
       - -c
       - >
+        trap 'touch /status/done' EXIT
+        &&
         make update-attribution-files
       env:
       - name: PROJECT_PATH
@@ -57,3 +60,9 @@ periodics:
         requests:
           memory: "16Gi"
           cpu: "5"
+    - command:
+      - sh
+      args:
+      - /disk-usage-script/entrypoint.sh
+      image: public.ecr.aws/amazonlinux/amazonlinux:2
+      name: disk-monitor

--- a/jobs/aws/eks-distro/eks-distro-checksum-periodics.yaml
+++ b/jobs/aws/eks-distro/eks-distro-checksum-periodics.yaml
@@ -35,6 +35,7 @@ periodics:
     s3_credentials_secret: s3-credentials
   labels:
     pr-creation: "true"
+    disk-usage: "true"
   spec:
     serviceaccountName: periodics-build-account
     automountServiceAccountToken: false
@@ -47,6 +48,8 @@ periodics:
       - bash
       - -c
       - >
+        trap 'touch /status/done' EXIT
+        &&
         make update-checksum-files
       env:
       - name: PROJECT_PATH
@@ -57,3 +60,9 @@ periodics:
         requests:
           memory: "16Gi"
           cpu: "5"
+    - command:
+      - sh
+      args:
+      - /disk-usage-script/entrypoint.sh
+      image: public.ecr.aws/amazonlinux/amazonlinux:2
+      name: disk-monitor

--- a/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
+++ b/jobs/aws/eks-distro/eks-distro-docs-postsubmits.yaml
@@ -34,6 +34,8 @@ postsubmits:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      disk-usage: "true"
     spec:
       serviceaccountName: docs-build-account
       automountServiceAccountToken: false
@@ -46,9 +48,17 @@ postsubmits:
         - bash
         - -c
         - >
+          trap 'touch /status/done' EXIT
+          &&
           make release -C $PROJECT_PATH
           &&
           mv ./docs/site/* /logs/artifacts
         env:
         - name: PROJECT_PATH
           value: "docs"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-21-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-22-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/prod-release-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-24-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/jobs/aws/eks-distro/prod-release-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-25-postsubmits.yaml
@@ -37,6 +37,7 @@ postsubmits:
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
       automountServiceAccountToken: false
@@ -86,3 +87,9 @@ postsubmits:
           requests:
             memory: "2Gi"
             cpu: "1024m"
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor

--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -88,8 +88,8 @@ func UnmarshalJobs(jobDir string) (map[string]types.JobConfig, error) {
 					return nil, fmt.Errorf("%v", err)
 				}
 
-                                 // If latest release branch, check if the release branch dir exists before executing cmd
-                                 // This allows us to experiment with adding prow jobs for new branches without failing other runs
+				// If latest release branch, check if the release branch dir exists before executing cmd
+				// This allows us to experiment with adding prow jobs for new branches without failing other runs
 				if len(releaseBranches)-1 == i {
 					for j, command := range jobConfig.Commands {
 						jobConfig.Commands[j] = "if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then " + command + "; fi"

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -36,7 +36,7 @@ periodics:
       bucket: {{ .bucket }}
       path_strategy: explicit
     s3_credentials_secret: s3-credentials
-  {{- if or .imageBuild .localRegistry .prCreation }}
+  {{- if or .imageBuild .localRegistry .prCreation .diskUsage }}
   labels:
     {{- if .imageBuild }}
     image-build: "true"
@@ -47,6 +47,9 @@ periodics:
     {{- if .prCreation }}
     pr-creation: "true"
     {{- end }}
+    {{- if .diskUsage }}
+    disk-usage: "true"
+    {{- end}}
   {{- end }}
   spec:
     serviceaccountName: {{ .serviceAccountName }}
@@ -60,9 +63,9 @@ periodics:
       - bash
       - -c
       - >
-        {{- if .imageBuild }}
         trap '{{- if .useDockerBuildX }}(docker buildx rm eks-d-builders || true) && {{ end }}touch /status/done' EXIT
         &&
+        {{- if .imageBuild }}
         {{- if eq .repoName "aws/eks-distro"}}
         build/lib/buildkit_check.sh
         {{- else }}
@@ -144,6 +147,14 @@ periodics:
         limits:
           memory: "1Gi"
           cpu: "256m"
+    {{- end }}
+    {{- if .diskUsage }}
+    - command:
+      - sh
+      args:
+      - /disk-usage-script/entrypoint.sh
+      image: public.ecr.aws/amazonlinux/amazonlinux:2
+      name: disk-monitor
     {{- end }}
     {{- if .volumes }}
     volumes:

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
         bucket: {{ .bucket }}
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-    {{- if or .imageBuild .localRegistry .prCreation }}
+    {{- if or .imageBuild .localRegistry .prCreation .diskUsage }}
     labels:
       {{- if .imageBuild }}
       image-build: "true"
@@ -61,6 +61,9 @@ postsubmits:
       {{- if .prCreation }}
       pr-creation: "true"
       {{- end }}
+      {{- if .diskUsage }}
+      disk-usage: "true"
+      {{- end}}
     {{- end }}
     spec:
       serviceaccountName: {{ .serviceAccountName }}
@@ -74,9 +77,9 @@ postsubmits:
         - bash
         - -c
         - >
-          {{- if .imageBuild }}
           trap '{{- if .useDockerBuildX }}(docker buildx rm eks-d-builders || true) && {{ end }}touch /status/done' EXIT
           &&
+          {{- if .imageBuild }}
           {{- if eq .repoName "aws/eks-distro"}}
           build/lib/buildkit_check.sh
           {{- else }}
@@ -158,6 +161,14 @@ postsubmits:
           limits:
             memory: "1Gi"
             cpu: "256m"
+      {{- end }}
+      {{- if .diskUsage }}
+      - command:
+        - sh
+        args:
+        - /disk-usage-script/entrypoint.sh
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        name: disk-monitor
       {{- end }}
       {{- if .volumes }}
       volumes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding to the rest of the jobs now that it has been working well on the presubmits since we enabled it last week.  I have verified all jobs have the trap /status/done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
