### PR TITLE
Adds checks for release branch directory

### DIFF
--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-25-presubmits.yaml
@@ -51,9 +51,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-25-presubmits.yaml
@@ -48,11 +48,11 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
           &&
-          mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts; fi
           &&
-          make clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
@@ -53,9 +53,9 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro; fi
           &&
-          make -j2 postsubmit-conformance
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make -j2 postsubmit-conformance; fi
         env:
         - name: PROJECT_PATH
           value: ""

--- a/jobs/aws/eks-distro/cni-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-25-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/coredns-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/dev-release-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-25-postsubmits.yaml
@@ -53,7 +53,7 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          ./release/prow.sh
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then ./release/prow.sh; fi
         env:
         - name: PROJECT_PATH
           value: ""

--- a/jobs/aws/eks-distro/etcd-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-25-presubmits.yaml
@@ -48,11 +48,11 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
           &&
-          mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts; fi
           &&
-          make clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/external-attacher-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-provisioner-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-resizer-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-snapshotter-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/kubernetes-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-25-presubmits.yaml
@@ -51,13 +51,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
           &&
-          make build -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
           &&
-          mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts; fi
           &&
-          make clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-1-25-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-25-test-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          make test -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make test -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-release-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/livenessprobe-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-25-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean-go-cache images clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache images clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/metrics-server-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-25-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          make build clean-go-cache clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-25-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-25-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          make build clean-go-cache images clean -C $PROJECT_PATH
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache images clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/jobs/aws/eks-distro/prod-release-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-25-postsubmits.yaml
@@ -53,7 +53,7 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          ./release/prow-release.sh
+          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then ./release/prow-release.sh; fi
         env:
         - name: PROJECT_PATH
           value: ""

--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -88,6 +88,8 @@ func UnmarshalJobs(jobDir string) (map[string]types.JobConfig, error) {
 					return nil, fmt.Errorf("%v", err)
 				}
 
+                                 // If latest release branch, check if the release branch dir exists before executing cmd
+                                 // This allows us to experiment with adding prow jobs for new branches without failing other runs
 				if len(releaseBranches)-1 == i {
 					for j, command := range jobConfig.Commands {
 						jobConfig.Commands[j] = "if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then " + command + "; fi"

--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -88,6 +88,12 @@ func UnmarshalJobs(jobDir string) (map[string]types.JobConfig, error) {
 					return nil, fmt.Errorf("%v", err)
 				}
 
+				if len(releaseBranches)-1 == i {
+					for j, command := range jobConfig.Commands {
+						jobConfig.Commands[j] = "if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then " + command + "; fi"
+					}
+				}
+
 				jobList[releaseBranchBasedFileName] = jobConfig
 			}
 		} else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For the latest release branch we could check if the folder exists for the current project before trying to build.  This is similar to what we use PROJECT_PATH for in eks-a ([ex](https://github.com/aws/eks-anywhere-prow-jobs/blob/main/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-23-presubmits.yaml#L50)).  This will allow us to check in new 1-25 jobs so we can test projects on eks-distro without breaking all other PRs until all the projects have had their 1-25 versions added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
