### PR TITLE
Update list of files that skip postsubmits

### DIFF
--- a/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
@@ -1,5 +1,5 @@
 jobName: build-{{ .releaseBranch }}-postsubmit
-skipIfOnlyChanged: {{ .otherReleaseBranches }}|docs/.*|.*\.md|.*\.mk|.*ATTRIBUTION\.txt|LICENSE|NOTICE|OWNERS
+skipIfOnlyChanged: {{ .otherReleaseBranches }}|docs/.*|.*\.md|.*Help\.mk|.*ATTRIBUTION\.txt|LICENSE|NOTICE|OWNERS
 imageBuild: true
 projectPath: projects/kubernetes/kubernetes
 commands:

--- a/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
@@ -1,5 +1,5 @@
 jobName: build-{{ .releaseBranch }}-postsubmit
-skipIfOnlyChanged: {{ .otherReleaseBranches }}|docs/.*
+skipIfOnlyChanged: {{ .otherReleaseBranches }}|docs/.*|.*\.md|.*\.mk|.*ATTRIBUTION\.txt|LICENSE|NOTICE|OWNERS
 imageBuild: true
 projectPath: projects/kubernetes/kubernetes
 commands:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates the list of files that will skip running the postsubmit jobs in our CI, which will lead to less resource usage/contention for changes that do need postsubmits

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
