### PR TITLE
Update prow plugin presubmit

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/prow-plugin-presubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prow-plugin-presubmit.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           scripts/buildkit_check.sh
           &&
-          make build-eksDistroOpsProwPlugin -C $PROJECT_PATH
+          make images-eksDistroOpsProwPlugin -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "tools/eksDistroBuildToolingOpsTools"

--- a/templater/jobs/presubmit/eks-distro-build-tooling/prow-plugin-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/prow-plugin-presubmit.yaml
@@ -2,7 +2,7 @@ jobName: prow-plugin-tooling-presubmit
 runIfChanged: tools/eksDistroBuildToolingOpsTools/.*
 imageBuild: true
 commands:
-- make build-eksDistroOpsProwPlugin -C $PROJECT_PATH
+- make images-eksDistroOpsProwPlugin -C $PROJECT_PATH
 projectPath: tools/eksDistroBuildToolingOpsTools
 resources:
   limits:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the make target from build to images to build and produce the image without pushing the image in the presubmit. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
