### PR TITLE
add updated eks go post-submits with image build

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-15-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-16-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-17-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-18-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro-build-tooling/golang-1-20-PROD-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-20-PROD-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: release-build-account
@@ -49,6 +50,8 @@ postsubmits:
         - -c
         - >
           trap 'touch /status/done' EXIT
+          &&
+          scripts/buildkit_check.sh
           &&
           make install-deps -C $PROJECT_PATH
           &&
@@ -66,6 +69,10 @@ postsubmits:
           value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: IMAGE_REPO
+          value: "public.ecr.aws/eks-distro-build-tooling"
+        - name: ECR_PUBLIC_PUSH_ROLE_ARN
+          value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
         resources:
           requests:
             memory: "16Gi"
@@ -73,6 +80,19 @@ postsubmits:
           limits:
             memory: "16Gi"
             cpu: "2560m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1024m"
       - command:
         - sh
         args:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-postsubmits.yaml
@@ -1,5 +1,6 @@
 jobName: golang-{{ .jobGoVersion }}-PROD-tooling-postsubmit
 runIfChanged: projects/golang/go/{{ .golangVersion }}/RELEASE
+imageBuild: true
 automountServiceAccountToken: true
 commands:
 - make install-deps -C $PROJECT_PATH
@@ -23,4 +24,8 @@ envVars:
     value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
   - name: AWS_REGION
     value: us-east-1
+  - name: IMAGE_REPO
+    value: public.ecr.aws/eks-distro-build-tooling
+  - name: ECR_PUBLIC_PUSH_ROLE_ARN
+    value: arn:aws:iam::832188789588:role/ECRPublicPushRole
 serviceAccountName: release-build-account


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
golang image build now supports both the prod release and the prod images release for the golang debian image; this sets up the prow job to also support this.

Part of https://github.com/aws/eks-distro-build-tooling/pull/865

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
