### PR TITLE
Changes release branch check

### DIFF
--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-26-presubmits.yaml
@@ -51,9 +51,9 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-26-presubmits.yaml
@@ -48,11 +48,11 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build -C $PROJECT_PATH; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/aws-iam-authenticator"

--- a/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
@@ -54,9 +54,9 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make -j2 postsubmit-conformance; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make -j2 postsubmit-conformance; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/cni-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-26-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/containernetworking/plugins"

--- a/jobs/aws/eks-distro/coredns-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/coredns/coredns"

--- a/jobs/aws/eks-distro/dev-release-1-26-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-26-postsubmits.yaml
@@ -54,7 +54,7 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then ./release/prow.sh; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then ./release/prow.sh; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/etcd-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-26-presubmits.yaml
@@ -48,11 +48,11 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build -C $PROJECT_PATH; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/etcd-io/etcd"

--- a/jobs/aws/eks-distro/external-attacher-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-attacher"

--- a/jobs/aws/eks-distro/external-provisioner-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-provisioner"

--- a/jobs/aws/eks-distro/external-resizer-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-resizer"

--- a/jobs/aws/eks-distro/external-snapshotter-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/external-snapshotter"

--- a/jobs/aws/eks-distro/kubernetes-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-26-presubmits.yaml
@@ -51,13 +51,13 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build -C $PROJECT_PATH; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts; fi
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-1-26-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-26-test-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make test -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make test -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/jobs/aws/eks-distro/kubernetes-release-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/release"

--- a/jobs/aws/eks-distro/livenessprobe-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-26-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache images clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache images clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/livenessprobe"

--- a/jobs/aws/eks-distro/metrics-server-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-26-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"

--- a/jobs/aws/eks-distro/node-driver-registrar-1-26-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-26-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
           &&
           build/lib/local_registry_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then make build clean-go-cache images clean -C $PROJECT_PATH; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then make build clean-go-cache images clean -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-csi/node-driver-registrar"

--- a/jobs/aws/eks-distro/prod-release-1-26-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-26-postsubmits.yaml
@@ -54,7 +54,7 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then ./release/prow-release.sh; fi
+          if $(make check-for-supported-release-branch -C $PROJECT_PATH); then ./release/prow-release.sh; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"

--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -200,7 +200,7 @@ func UnmarshalJobs(jobDir string) (map[string]types.JobConfig, error) {
 
 		if latest, ok := data["latestReleaseBranch"]; ok && latest.(bool) {
 			for j, command := range jobConfig.Commands {
-				jobConfig.Commands[j] = "if [ -d $PROJECT_PATH/$RELEASE_BRANCH ]; then " + command + "; fi"
+				jobConfig.Commands[j] = "if $(make check-for-supported-release-branch -C $PROJECT_PATH); then " + command + "; fi"
 			}
 		}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Since we are using the templater as a libary over in eks-a-prow-jobs, the release branch directory check is bleeding over to some of the [jobs](https://github.com/aws/eks-anywhere-prow-jobs/blob/main/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml#L49) there.  Some of the builds in eks-a do not have release branch folders, yet are "release branched". 

This PR changes the prow jobs to instead call a make target vs simply checking for the existence of the folder.  This chekc is added [here](https://github.com/aws/eks-distro/pull/1844/files#diff-6daeb9c300098022af9eb1c5f69e52ffbd840490fd9945ac9c3e2d02ad838ab7R963) and for eks-d is just the folder check.

For eks-a, we can change the [definition](https://github.com/aws/eks-anywhere-build-tooling/pull/1972/files#diff-6daeb9c300098022af9eb1c5f69e52ffbd840490fd9945ac9c3e2d02ad838ab7R962) to handle the special cases.  This new method could also be used to guard certain codebuild jobs on the eks-a side to avoid false negatives in our build reporting.

Once this merged, we can update eks-anywhere-prow-jobs and regenerate those templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
