### PR TITLE
Create quarterly rebuild minimal image prowjob

### DIFF
--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-quarterly-minimal-image-rebuild.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-quarterly-minimal-image-rebuild.yaml
@@ -1,0 +1,27 @@
+jobName: eks-distro-quarterly-minimal-image-rebuild-periodic
+cronExpression: 0 0 1 */3 *
+prCreation: true
+architecture: AMD64
+automountServiceAccountToken: true
+commands:
+- export DATE_EPOCH=$(date "+%F-%s")
+- make rebuild-minimal-images
+- make create-rebuild-pr 
+projectPath: eks-distro-base
+envVars:
+- name: REPO_OWNER
+  value: aws
+- name: OUTPUT_DEBUG_LOG
+  value: true
+extraRefs:
+- baseRef: main
+  org: aws
+  repo: eks-distro-build-tooling
+- baseRef: main
+  org: eks-distro-pr-bot
+  repo: eks-distro-build-tooling
+resources:
+  requests:
+    cpu: "5"
+    memory: 16Gi
+timeout: 4h


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This prowjob will trigger the minimal image rebuild once on the first day of every quarter at midnight.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
