### PR TITLE
Revert "Remove 1.23 prowjobs (#526)"

### DIFF
--- a/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-cloud-controller-manager-1-23-presubmits.yaml
@@ -18,31 +18,26 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: aws-cloud-controller-manager-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      local-registry: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +45,28 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          build/lib/local_registry_check.sh
           &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          &&
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes/cloud-provider-aws"
+        - name: RELEASE_PROJECT_PATH
+          value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "localhost:5000"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +76,18 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
+      - name: registry
+        image: public.ecr.aws/docker/library/registry:2
+        command:
+        - sh
+        args:
+        - /registry-script/entrypoint.sh
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 3
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: aws-iam-authenticator-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/aws-iam-authenticator/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,24 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          make build -C $PROJECT_PATH
           &&
-          make -j2 postsubmit-conformance
+          mv ./projects/kubernetes-sigs/aws-iam-authenticator/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-sigs/aws-iam-authenticator"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +71,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-23-postsubmits.yaml
@@ -20,9 +20,9 @@
 
 postsubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: build-1-23-postsubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    skip_if_only_changed: "1-24|1-25|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
     branches:
     - ^main$
     max_concurrency: 10
@@ -65,7 +65,7 @@ postsubmits:
         - name: ARTIFACT_BUCKET
           value: "eks-d-postsubmit-artifacts"
         - name: RELEASE_BRANCH
-          value: "1-25"
+          value: "1-23"
         - name: CONTROL_PLANE_INSTANCE_PROFILE
           value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
         - name: NODE_INSTANCE_PROFILE

--- a/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-24-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro:
   - name: build-1-24-postsubmit
     always_run: false
-    skip_if_only_changed: "1-25|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    skip_if_only_changed: "1-23|1-25|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro:
   - name: build-1-26-postsubmit
     always_run: false
-    skip_if_only_changed: "1-24|1-25|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    skip_if_only_changed: "1-23|1-24|1-25|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro/build-1-27-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-27-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro:
   - name: build-1-27-postsubmit
     always_run: false
-    skip_if_only_changed: "1-24|1-25|1-26|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    skip_if_only_changed: "1-23|1-24|1-25|1-26|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro/build-1-28-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-28-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro:
   - name: build-1-28-postsubmit
     always_run: false
-    skip_if_only_changed: "1-24|1-25|1-26|1-27|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    skip_if_only_changed: "1-23|1-24|1-25|1-26|1-27|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-1-23-presubmits.yaml
@@ -18,31 +18,24 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: cni-plugins-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "^build/lib/.*|Common.mk|projects/containernetworking/plugins/(build|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
-      image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,45 +43,14 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          build/lib/buildkit_check.sh
-          &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/containernetworking/plugins"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
-        resources:
-          requests:
-            memory: "8Gi"
-            cpu: "2"
-      - name: buildkitd
-        image: moby/buildkit:v0.10.5-rootless
-        command:
-        - sh
-        args:
-        - /script/entrypoint.sh
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
+          value: "1-23"
         resources:
           requests:
             memory: "2Gi"

--- a/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: coredns-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/coredns/coredns/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,22 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/coredns/coredns"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +69,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/dev-release-1-23-postsubmits.yaml
@@ -20,17 +20,17 @@
 
 postsubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: dev-release-1-23-postsubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    run_if_changed: "release/1-23/development/RELEASE"
     branches:
     - ^main$
-    max_concurrency: 10
+    max_concurrency: 1
     error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 4h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
@@ -54,32 +54,22 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          ./release/prow.sh
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
+        - name: AWS_REGION
+          value: "us-east-1"
         - name: ARTIFACT_BUCKET
           value: "eks-d-postsubmit-artifacts"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: etcd-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/etcd-io/etcd/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,26 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          make build -C $PROJECT_PATH
           &&
-          make -j2 postsubmit-conformance
+          mv ./projects/etcd-io/etcd/_output/tar/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/etcd-io/etcd"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +73,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: external-attacher-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-attacher/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/external-attacher"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: external-provisioner-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-provisioner/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/external-provisioner"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: external-resizer-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-resizer/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/external-resizer"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: external-snapshotter-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/external-snapshotter/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/external-snapshotter"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
             memory: "8Gi"
-            cpu: "2"
+            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-presubmits.yaml
@@ -18,31 +18,26 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: kubernetes-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_IPTABLES_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/kubernetes/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      local-registry: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +45,32 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          build/lib/local_registry_check.sh
           &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $RELEASE_PROJECT_PATH IMAGE_OUTPUT_TYPE=image IMAGE_OUTPUT=push=true
+          &&
+          make build -C $PROJECT_PATH
+          &&
+          mv ./projects/kubernetes/kubernetes/_output/${RELEASE_BRANCH}/* /logs/artifacts
+          &&
+          make clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+        - name: RELEASE_PROJECT_PATH
+          value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "localhost:5000"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "32Gi"
+            cpu: "16"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +80,18 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
+      - name: registry
+        image: public.ecr.aws/docker/library/registry:2
+        command:
+        - sh
+        args:
+        - /registry-script/entrypoint.sh
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 3
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-23-test-presubmits.yaml
@@ -18,31 +18,24 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: kubernetes-1-23-test-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "projects/kubernetes/kubernetes/1-23/(GIT_TAG|patches)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
-      image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,49 +43,18 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          build/lib/buildkit_check.sh
-          &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make test -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
-      - name: buildkitd
-        image: moby/buildkit:v0.10.5-rootless
-        command:
-        - sh
-        args:
-        - /script/entrypoint.sh
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
+            memory: "32Gi"
+            cpu: "16"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: kubernetes-release-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/release/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes/release"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
             memory: "8Gi"
-            cpu: "2"
+            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-1-23-presubmits.yaml
@@ -18,31 +18,26 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: livenessprobe-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKS_DISTRO_WINDOWS_BASE_.*_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/livenessprobe/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      local-registry: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +45,24 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          build/lib/local_registry_check.sh
           &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache images clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/livenessprobe"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "localhost:5000"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +72,18 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
+      - name: registry
+        image: public.ecr.aws/docker/library/registry:2
+        command:
+        - sh
+        args:
+        - /registry-script/entrypoint.sh
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 3
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-1-23-presubmits.yaml
@@ -18,31 +18,25 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: metrics-server-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/metrics-server/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +44,20 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-sigs/metrics-server"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
-        - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "1-23"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +67,6 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-1-23-presubmits.yaml
@@ -18,31 +18,26 @@
 # how to add a new Prowjob or update an existing Prowjob.
 ################################################################################
 
-postsubmits:
+presubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: node-driver-registrar-1-23-presubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
-    branches:
-    - ^main$
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKS_DISTRO_WINDOWS_BASE_.*_FILE|^build/lib/.*|Common.mk|projects/kubernetes-csi/node-driver-registrar/(build|docker|Makefile|1-23)"
     max_concurrency: 10
-    error_on_eviction: true
-    cluster: "prow-postsubmits-cluster"
+    cluster: "prow-presubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
       gcs_configuration:
-        bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
       image-build: "true"
+      local-registry: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
-      nodeSelector:
-        arch: AMD64
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-875f14aa285cd879ded85d553f44fa919fd962eb.2
@@ -50,36 +45,24 @@ postsubmits:
         - bash
         - -c
         - >
-          trap 'touch /status/done' EXIT
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
+          build/lib/local_registry_check.sh
           &&
-          make -j2 postsubmit-conformance
+          make build clean-go-cache images clean -C $PROJECT_PATH
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
-        - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "projects/kubernetes-csi/node-driver-registrar"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "localhost:5000"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "4Gi"
+            cpu: "1024m"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:
@@ -89,10 +72,18 @@ postsubmits:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1024m"
+      - name: registry
+        image: public.ecr.aws/docker/library/registry:2
+        command:
+        - sh
+        args:
+        - /registry-script/entrypoint.sh
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 3
       - command:
         - sh
         args:

--- a/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
+++ b/jobs/aws/eks-distro/prod-release-1-23-postsubmits.yaml
@@ -20,17 +20,17 @@
 
 postsubmits:
   aws/eks-distro:
-  - name: build-1-25-postsubmit
+  - name: prod-release-1-23-postsubmit
     always_run: false
-    skip_if_only_changed: "1-23|1-24|1-26|1-27|1-28|docs/.*|.*.md|go.sum|go.mod|.*Help.mk|.*ATTRIBUTION.txt|LICENSE|NOTICE|OWNERS"
+    run_if_changed: "release/1-23/production/RELEASE"
     branches:
     - ^main$
-    max_concurrency: 10
+    max_concurrency: 1
     error_on_eviction: true
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 4h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit
@@ -39,7 +39,7 @@ postsubmits:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: false
       nodeSelector:
         arch: AMD64
@@ -54,32 +54,26 @@ postsubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          cp -r "${HOME}/.docker" /home/prow/go/src/github.com/aws/eks-distro
-          &&
-          make -j2 postsubmit-conformance
+          ./release/prow-release.sh
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/kubernetes"
-        - name: TEST_ROLE_ARN
-          value: "arn:aws:iam::125833916567:role/TestBuildRole"
+        - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
+          value: "arn:aws:iam::379412251201:role/ArtifactDeploymentRole"
+        - name: AWS_REGION
+          value: "us-east-1"
+        - name: RELEASE_ENVIRONMENT
+          value: "production"
         - name: ARTIFACT_BUCKET
-          value: "eks-d-postsubmit-artifacts"
+          value: "artifactsstack-3794122512-artifactsbucket2aac5544-1f3dgu9wrpiz2"
         - name: RELEASE_BRANCH
-          value: "1-25"
-        - name: CONTROL_PLANE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsControlPlaneBuildRole"
-        - name: NODE_INSTANCE_PROFILE
-          value: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
-        - name: KOPS_STATE_STORE
-          value: "s3://testbuildstack-125833916-kopsbuildstatestorebucke-d4esen60nfrk"
+          value: "1-23"
         - name: IMAGE_REPO
-          value: "public.ecr.aws/h1r8a7l5"
-        - name: DOCKER_CONFIG
-          value: "/home/prow/go/src/github.com/aws/eks-distro/.docker"
+          value: "public.ecr.aws/eks-distro"
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "16Gi"
+            cpu: "4"
       - name: buildkitd
         image: moby/buildkit:v0.10.5-rootless
         command:

--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -14,6 +14,7 @@ import (
 )
 
 var releaseBranches = []string{
+	"1-23",
 	"1-24",
 	"1-25",
 	"1-26",


### PR DESCRIPTION
This reverts commit 90d5f88ee7f1e2ec5940a3b4ae1cac1991cab845.


*Description of changes:*
Revert https://github.com/aws/eks-distro-prow-jobs/pull/526

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
