### PR TITLE
Configure ephemeral storage to be a standard resource

### DIFF
--- a/jobs/aws/eks-distro/kubernetes-1-28-test-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-28-test-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
           requests:
             memory: "32Gi"
             cpu: "16"
-            ephemeralStorage: "50Gi"
+            ephemeral-storage: "50Gi"
       - command:
         - sh
         args:

--- a/templater/jobs/presubmit/eks-distro/kubernetes-1-X-test-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro/kubernetes-1-X-test-presubmits.yaml
@@ -28,6 +28,6 @@ resources:
     cpu: 16
     memory: 32Gi
     {{ if eq .releaseBranch "1-28" }}
-    ephemeralStorage: "50Gi"
+    ephemeral-storage: "50Gi"
     {{ end }}
 {{ end }}

--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -19,7 +19,7 @@ type Resources struct {
 type ResourceConfig struct {
 	CPU              string `json:"cpu,omitempty"`
 	Memory           string `json:"memory,omitempty"`
-	EphemeralStorage string `json:"ephemeralStorage,omitempty"`
+	EphemeralStorage string `json:"ephemeral-storage,omitempty"`
 }
 
 type HostPath struct {

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -117,7 +117,7 @@ presubmits:
             memory: "{{ .resources.Requests.Memory }}"
             cpu: "{{ .resources.Requests.CPU }}"
             {{- if .resources.Requests.EphemeralStorage }}
-            ephemeralStorage: "{{ .resources.Requests.EphemeralStorage }}"
+            ephemeral-storage: "{{ .resources.Requests.EphemeralStorage }}"
             {{- end }}
           {{- end }}
         {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
This change changes ephemeralStorage field to ephemeral-storage to be a standard resource


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
