### PR TITLE
Update storage size for kops-presubmits

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/kops-presubmits.yaml
@@ -53,6 +53,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "2560m"
+            ephemeral-storage: "50Gi"
       - command:
         - sh
         args:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/kops-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/kops-presubmits.yaml
@@ -10,3 +10,4 @@ resources:
   requests:
     cpu: "2560m"
     memory: 16Gi
+    ephemeral-storage: 50Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[Kops-Presubmit jobs](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-distro-build-tooling/1141/kops-tooling-presubmit/1703871240634109952) are failing in eks-distro-build-tooing this should bump the storage to allow the jobs to complete

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
