### PR TITLE
Make job run twice a day vs once

### DIFF
--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-al-X.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-al-X.yaml
@@ -1,5 +1,5 @@
 jobName: eks-distro-base-tooling-periodic-al-{{ .alVersion }}
-cronExpression: 0 19 * * 1-5
+cronExpression: 0 7,19 * * 1-5
 imageBuild: true
 prCreation: true
 architecture: AMD64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Will run at midnight and noon PT every day on weekdays. This is to help speed up minimal image rebuilds instead of waiting for the job to run or kicking it off manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
