### PR TITLE
Update service account similar to access artifact account

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-19-PROD-images-postsubmits.yaml
@@ -38,7 +38,7 @@ postsubmits:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64

--- a/jobs/aws/eks-distro-build-tooling/golang-1-20-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-20-PROD-images-postsubmits.yaml
@@ -38,7 +38,7 @@ postsubmits:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64

--- a/jobs/aws/eks-distro-build-tooling/golang-1-21-PROD-images-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/golang-1-21-PROD-images-postsubmits.yaml
@@ -38,7 +38,7 @@ postsubmits:
       image-build: "true"
       disk-usage: "true"
     spec:
-      serviceaccountName: postsubmits-build-account
+      serviceaccountName: release-build-account
       automountServiceAccountToken: true
       nodeSelector:
         arch: AMD64

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-images-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/golang-1-X-PROD-images-postsubmits.yaml
@@ -3,9 +3,9 @@ runIfChanged: projects/golang/go/docker/debianBase/RELEASE
 imageBuild: true
 automountServiceAccountToken: true
 commands:
-- make install-deps -C $PROJECT_PATH
-- projects/golang/go/scripts/prow_release_images.sh
-- projects/golang/go/scripts/debian_image_release_notification.sh
+  - make install-deps -C $PROJECT_PATH
+  - projects/golang/go/scripts/prow_release_images.sh
+  - projects/golang/go/scripts/debian_image_release_notification.sh
 projectPath: projects/golang/go
 resources:
   requests:
@@ -24,3 +24,4 @@ envVars:
     value: arn:aws:sns:us-east-1:379412251201:eks-golang-image-updates
   - name: ARTIFACT_DEPLOYMENT_ROLE_ARN
     value: arn:aws:iam::379412251201:role/ArtifactDeploymentRole
+serviceAccountName: release-build-account


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The debian releases are still failing due to not having correct permissions. Comparing the differences between the nonDebian sns message and debian sns message is the service account used. Similar to https://github.com/aws/eks-distro-prow-jobs/pull/377

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
