### PR TITLE
adds support for setting runAsUser and runAsGroup

### DIFF
--- a/templater/jobs/types/types.go
+++ b/templater/jobs/types/types.go
@@ -71,4 +71,6 @@ type JobConfig struct {
 	Cluster                      string         `json:"cluster,omitempty"`
 	Bucket                       string         `json:"bucket,omitempty"`
 	ProjectPath                  string         `json:"projectPath,omitempty"`
+	RunAsUser                    string         `json:"runAsUser,omitempty"`
+	RunAsGroup                   string         `json:"runAsGroup,omitempty"`
 }

--- a/templater/main.go
+++ b/templater/main.go
@@ -113,6 +113,8 @@ func main() {
 					"bucket":                       bucket,
 					"projectPath":                  jobConfig.ProjectPath,
 					"diskUsage":                    true,
+					"runAsUser":                    jobConfig.RunAsUser,
+					"runAsGroup":                   jobConfig.RunAsGroup,
 				}
 
 				err := GenerateProwjob(fileName, template, data)

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -110,6 +110,15 @@ presubmits:
           value: "{{ .Value }}"
         {{- end }}
         {{- end }}
+        {{- if or .runAsUser .runAsGroup }}
+        securityContext:
+          {{- if .runAsUser }}
+          runAsUser: {{ .runAsUser }}
+          {{- end }}
+          {{- if .runAsGroup }}
+          runAsGroup: {{ .runAsGroup }}
+          {{- end }}
+        {{- end }}
         {{- if .resources }}
         resources:
           {{- if .resources.Requests }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We want to try running our image builder presubmits in eks-a as the imagebuilder user to try and catch things that bite us in codebuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
