### PR TITLE
Generalize supported branches for K8 patches

### DIFF
--- a/templater/jobs/utils/utils.go
+++ b/templater/jobs/utils/utils.go
@@ -22,6 +22,10 @@ var releaseBranches = []string{
 	"1-29",
 }
 
+var k8releaseBranches = []string{
+	"1-23",
+}
+
 var golangVersions = []string{
 	"1-19",
 	"1-20",
@@ -123,11 +127,17 @@ func AddReleaseBranch(fileName string, data map[string]interface{}) map[string]m
 	if !strings.Contains(fileName, "1-X") {
 		return jobList
 	}
+	currentReleaseBranches := releaseBranches
 
-	for i, releaseBranch := range releaseBranches {
+	if strings.Contains(fileName, "kubernetes") && !strings.Contains(fileName, "release") {
+		currentReleaseBranches = append(k8releaseBranches, releaseBranches...)
+	}
+
+	for i, releaseBranch := range currentReleaseBranches {
+
 		releaseBranchBasedFileName := strings.ReplaceAll(fileName, "1-X", releaseBranch)
-		otherReleaseBranches := append(append([]string{}, releaseBranches[:i]...),
-			releaseBranches[i+1:]...)
+		otherReleaseBranches := append(append([]string{}, currentReleaseBranches[:i]...),
+			currentReleaseBranches[i+1:]...)
 		jobList[releaseBranchBasedFileName] = AppendMap(data, map[string]interface{}{
 			"releaseBranch":        releaseBranch,
 			"otherReleaseBranches": strings.Join(otherReleaseBranches, "|"),
@@ -135,7 +145,7 @@ func AddReleaseBranch(fileName string, data map[string]interface{}) map[string]m
 
 		// If latest release branch, check if the release branch dir exists before executing cmd
 		// This allows us to experiment with adding prow jobs for new branches without failing other runs
-		if len(releaseBranches)-1 == i {
+		if len(currentReleaseBranches)-1 == i {
 			jobList[releaseBranchBasedFileName]["latestReleaseBranch"] = true
 		}
 	}

--- a/templater/scripts/verify-prowjobs.sh
+++ b/templater/scripts/verify-prowjobs.sh
@@ -6,10 +6,10 @@ set -o pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-DIFF_LINE_COUNT=$(git diff --name-only $REPO_ROOT/jobs ':(exclude,top)*-1-23-*' | wc -l)
+DIFF_LINE_COUNT=$(git diff --name-only $REPO_ROOT/jobs | wc -l)
 if [ $DIFF_LINE_COUNT -ne 0 ]; then
-    CHANGED_FILES=$(git diff --name-only $REPO_ROOT/jobs ':(exclude,top)*-1-23-*')
-    git diff $REPO_ROOT/jobs ':(exclude,top)*-1-23-*'
+    CHANGED_FILES=$(git diff --name-only $REPO_ROOT/jobs)
+    git diff $REPO_ROOT/jobs
     echo "\n❌ Detected discrepancies between generated and expected Prowjobs!"
     echo "The following generated files need to be checked in:\n"
     echo "${CHANGED_FILES}\n" | tr ' ' '\n'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 We need to track the list of unsupported branches for which we sync k8 patches. To test these patches the `kubernetes-presubmit` and `kubernetes-presubmit-test` prowjobs are needed.  

Adding a new list of branches called the `k8releaseBranches` will help to track these branches which are unsupported versions but for which k8 patches are synced with EKS. 

Pair PR in EKS-Distro: https://github.com/aws/eks-distro/pull/2642

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
