### PR TITLE
Increase build-1-X-postsubmits timeout to 8h

### DIFF
--- a/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-25-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-26-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/build-1-27-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-27-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/build-1-28-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-28-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/build-1-29-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-29-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/jobs/aws/eks-distro/build-1-30-postsubmits.yaml
+++ b/jobs/aws/eks-distro/build-1-30-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     cluster: "prow-postsubmits-cluster"
     skip_report: false
     decoration_config:
-      timeout: 6h
+      timeout: 8h
       gcs_configuration:
         bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
         path_strategy: explicit

--- a/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
+++ b/templater/jobs/postsubmit/eks-distro/build-1-X-postsubmits.yaml
@@ -26,4 +26,4 @@ resources:
   requests:
     cpu: "2"
     memory: 8Gi
-timeout: 6h
+timeout: 8h


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase build-1-X-postsubmits timeout to 8h

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
