### PR TITLE
Turn off auto garbage collection to help with big patches

### DIFF
--- a/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
+++ b/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
@@ -49,8 +49,8 @@ periodics:
       - -c
       - >
         trap 'touch /status/done' EXIT
-	&& 
-	git config --global gc.auto 0
+        &&
+        git config --global gc.auto 0
         &&
         make update-attribution-files
       env:

--- a/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
+++ b/jobs/aws/eks-distro/eks-distro-attribution-periodics.yaml
@@ -49,6 +49,8 @@ periodics:
       - -c
       - >
         trap 'touch /status/done' EXIT
+	&& 
+	git config --global gc.auto 0
         &&
         make update-attribution-files
       env:

--- a/templater/jobs/periodic/eks-distro/eks-distro-attribution-periodics.yaml
+++ b/templater/jobs/periodic/eks-distro/eks-distro-attribution-periodics.yaml
@@ -2,6 +2,7 @@ jobName: eks-distro-attribution-periodic
 cronExpression: 0 8 * * 1-5
 prCreation: true
 commands:
+- git config --global gc.auto 0
 - make update-attribution-files
 envVars:
 - name: REPO_OWNER


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We recently added a big patch that vendored deps, which caused the clean up command to fail because the .git file was still in use likely due to a race between the git gc and clean up of some huge patch files. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
