### PR TITLE
Use standard builder-base in golang image presubmits

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-20-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-20-al-2.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-20-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-20-al-2023.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-21-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-21-al-2.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-21-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-21-al-2023.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2023.yaml
@@ -53,7 +53,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:minimal-9be578bba75e08f01086ce11820e3ab6cdf63601.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-9be578bba75e08f01086ce11820e3ab6cdf63601.2
         command:
         - bash
         - -c

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-X-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-X-al-X.yaml
@@ -3,7 +3,7 @@ runIfChanged: eks-distro-base/.*|scripts/setup_public_ecr_push.sh
 imageBuild: true
 localRegistry: true
 useDockerBuildX: true
-useMinimalBuilderBase: true
+useMinimalBuilderBase: false
 commands:
 - export DATE_EPOCH=$(date "+%F-%s")
 - make golang-{{ .golangVersion }}-compiler-images -C $PROJECT_PATH IMAGE_TAG=${DATE_EPOCH}.${AL_TAG}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the way we generate the golang compiler images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
