### PR TITLE
Add EKS-A build account to Prow cred helpers config

### DIFF
--- a/config/docker-ecr-config.json
+++ b/config/docker-ecr-config.json
@@ -3,7 +3,8 @@
         "316434458148.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "862665599504.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "520703868821.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
-        "382577505035.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",        
+        "382577505035.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
+        "857151390494.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "public.ecr.aws": "ecr-login"
     }
 }


### PR DESCRIPTION
We need this to be able to use the build account ECR cache in EKS-A presubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
