### PR TITLE
Change periodic to once daily at 5

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/check_upstream_golang_release.yaml
+++ b/jobs/aws/eks-distro-build-tooling/check_upstream_golang_release.yaml
@@ -20,7 +20,7 @@
 
 periodics:
 - name: check-upstream-golang-release
-  cron: "0 7,14 * * 1-5"
+  cron: "0 5 * * 1-5"
   cluster: "prow-postsubmits-cluster"
   error_on_eviction: true
   extra_refs:

--- a/templater/jobs/periodic/eks-distro-build-tooling/check_upstream_golang_release.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/check_upstream_golang_release.yaml
@@ -1,5 +1,5 @@
 jobName: check-upstream-golang-release
-cronExpression: 0 7,14 * * 1-5
+cronExpression: 0 5 * * 1-5
 imageBuild: true
 prCreation: true
 architecture: AMD64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a new golang release comes out it opens a PR but then the next run of hte periodic fails because we haven't merged the PR yet. Update to only run 1x/day. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
