### PR TITLE
Remove extra ref for eks-anywhere-build-tooling

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/check_upstream_golang_release.yaml
+++ b/jobs/aws/eks-distro-build-tooling/check_upstream_golang_release.yaml
@@ -34,9 +34,6 @@ periodics:
     repo: eks-distro
     base_ref: main
   - org: eks-distro-pr-bot
-    repo: eks-anywhere-build-tooling
-    base_ref: main
-  - org: eks-distro-pr-bot
     repo: eks-anywhere
     base_ref: main
   decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-al-2.yaml
@@ -34,9 +34,6 @@ periodics:
     repo: eks-distro
     base_ref: main
   - org: eks-distro-pr-bot
-    repo: eks-anywhere-build-tooling
-    base_ref: main
-  - org: eks-distro-pr-bot
     repo: eks-anywhere
     base_ref: main
   decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics-al-2023.yaml
@@ -34,9 +34,6 @@ periodics:
     repo: eks-distro
     base_ref: main
   - org: eks-distro-pr-bot
-    repo: eks-anywhere-build-tooling
-    base_ref: main
-  - org: eks-distro-pr-bot
     repo: eks-anywhere
     base_ref: main
   decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2.yaml
@@ -37,9 +37,6 @@ postsubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2023.yaml
@@ -37,9 +37,6 @@ postsubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-22-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-23-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-23-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-23-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-23-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-7-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-7-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-7-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-7-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-9-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-9-al-2.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-9-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-9-al-2023.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
@@ -34,9 +34,6 @@ presubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -37,9 +37,6 @@ postsubmits:
       repo: eks-distro
       base_ref: main
     - org: eks-distro-pr-bot
-      repo: eks-anywhere-build-tooling
-      base_ref: main
-    - org: eks-distro-pr-bot
       repo: eks-anywhere
       base_ref: main
     decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-2.yaml
@@ -34,9 +34,6 @@ periodics:
     repo: eks-distro
     base_ref: main
   - org: eks-distro-pr-bot
-    repo: eks-anywhere-build-tooling
-    base_ref: main
-  - org: eks-distro-pr-bot
     repo: eks-anywhere
     base_ref: main
   decoration_config:

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-2023.yaml
@@ -34,9 +34,6 @@ periodics:
     repo: eks-distro
     base_ref: main
   - org: eks-distro-pr-bot
-    repo: eks-anywhere-build-tooling
-    base_ref: main
-  - org: eks-distro-pr-bot
     repo: eks-anywhere
     base_ref: main
   decoration_config:

--- a/templater/jobs/periodic/eks-distro-build-tooling/check_upstream_golang_release.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/check_upstream_golang_release.yaml
@@ -39,8 +39,5 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 timeout: 8h

--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-al-X.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-periodics-al-X.yaml
@@ -40,8 +40,5 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 timeout: 8h

--- a/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-X.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/eks-distro-base-tooling-quarterly-update-al-X.yaml
@@ -40,8 +40,5 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 timeout: 8h

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-al-X.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-al-X.yaml
@@ -34,9 +34,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-tag-files-update-postsubmit.yaml
@@ -16,7 +16,4 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-compiler-base-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-csi-ebs-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-docker-client-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-git-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-X-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-golang-1-X-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-haproxy-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-iptables-al-X.yaml
@@ -27,9 +27,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-java-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-kind-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nginx-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nodejs-16-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-nsenter-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-X-al-X.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-python-3-X-al-X.yaml
@@ -25,9 +25,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
@@ -23,9 +23,6 @@ extraRefs:
   repo: eks-distro
 - baseRef: main
   org: eks-distro-pr-bot
-  repo: eks-anywhere-build-tooling
-- baseRef: main
-  org: eks-distro-pr-bot
   repo: eks-anywhere
 resources:
   requests:


### PR DESCRIPTION
After [this](https://github.com/aws/eks-anywhere-build-tooling/pull/4195) change in eks-anywhere-build-tooling, this automation is no longer required since the new images are polled for and updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
