### PR TITLE
Increase disk space when building Windows Container image

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
@@ -83,6 +83,7 @@ presubmits:
           requests:
             memory: "4Gi"
             cpu: "1024m"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: moby/buildkit:v0.12.3-rootless
         command:

--- a/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
+++ b/templater/jobs/presubmit/eks-distro-build-tooling/eks-distro-base-presubmits-windows.yaml
@@ -28,3 +28,4 @@ resources:
   requests:
     cpu: 1024m
     memory: 4Gi
+    ephemeral-storage: "50Gi"


### PR DESCRIPTION
*Issue #, if available:*
Prow jobs are failing with `no space left on device`, refer [prow job logs.](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-distro-build-tooling/1696/eks-distro-base-tooling-presubmits-windows/1919404211620024320#2:build-container-build-log.txt%3A827). This error started after adding support to build WS2025 container image.

*Description of changes:*
This [PR](https://github.com/aws/eks-distro-build-tooling/pull/1696) add support to building Windows Server 2025 container images. Unfortuntanely, prow jobs are failing with `no space left on device`, refer [prow job logs](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-distro-build-tooling/1696/eks-distro-base-tooling-presubmits-windows/1919404211620024320#2:build-container-build-log.txt%3A827). This increase is required to address this issue.

*Testing*
`make verify-prowjobs` succeeds.
```
make verify-prowjobs -C templater
go fmt ./...
go generate ./...
go vet ./...
go build -o ./bin/generate-prowjobs github.com/aws/eks-distro-prow-jobs/templater
./bin/generate-prowjobs
./scripts/verify-prowjobs.sh
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
