### PR TITLE
set linter to use go 1.23

### DIFF
--- a/linter/Makefile
+++ b/linter/Makefile
@@ -5,7 +5,7 @@ ifndef PULL_PULL_SHA
 export PULL_PULL_SHA=$(shell git show -s --format=%H)
 endif
 
-export PATH:=/go/go1.24/bin:$(PATH)
+export PATH:=/go/go1.23/bin:$(PATH)
 
 BIN_DIR := bin
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
