### PR TITLE
fix: prevent script injection in base-image-pr-notifier

### DIFF
--- a/.github/workflows/builder-baseimage-pr-notifier.yml
+++ b/.github/workflows/builder-baseimage-pr-notifier.yml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title and notify Slack
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ "${{ github.event.pull_request.title }}" == *"Update builder-base image"* ]]; then
+          if [[ "$PR_TITLE" == *"Update builder-base image"* ]]; then
             curl -X POST $SLACK_WEBHOOK
             echo "Base image update detected - Slack notification sent"
           else


### PR DESCRIPTION
- Move PR title to environment variable to prevent shell injection
- Maintains identical functionality

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
