### PR TITLE
Added useDockerBuildX true to go-runner periodic job

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/go-runner-images-periodics-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/go-runner-images-periodics-al-2.yaml
@@ -19,10 +19,14 @@
 ################################################################################
 
 periodics:
-- name: go-runner-images-postsubmit-al-2
-  cron: "0 20 * * 1-5"
+- name: go-runner-images-periodic-al-2
+  cron: "0 23 * * 1-5"
   cluster: "prow-postsubmits-cluster"
   error_on_eviction: true
+  extra_refs:
+  - org: aws
+    repo: eks-distro-build-tooling
+    base_ref: main
   decoration_config:
     gcs_configuration:
       bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
@@ -32,7 +36,7 @@ periodics:
     image-build: "true"
     disk-usage: "true"
   spec:
-    serviceaccountName: periodics-build-account
+    serviceaccountName: postsubmits-build-account
     automountServiceAccountToken: true
     nodeSelector:
       arch: AMD64
@@ -43,9 +47,11 @@ periodics:
       - bash
       - -c
       - >
-        trap 'touch /status/done' EXIT
+        trap '(docker buildx rm eks-d-builders || true) && touch /status/done' EXIT
         &&
         scripts/buildkit_check.sh
+        &&
+        scripts/setup_buildx.sh
         &&
         projects/go-runner/scripts/prow_release_images.sh
       env:
@@ -60,6 +66,10 @@ periodics:
       - name: ECR_PUBLIC_PUSH_ROLE_ARN
         value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
       - name: PUSH_IMAGES
+        value: "true"
+      - name: BUILDKITD_IMAGE
+        value: "moby/buildkit:v0.12.3-rootless"
+      - name: USE_BUILDX
         value: "true"
       resources:
         requests:

--- a/jobs/aws/eks-distro-build-tooling/go-runner-images-periodics-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/go-runner-images-periodics-al-2023.yaml
@@ -19,10 +19,14 @@
 ################################################################################
 
 periodics:
-- name: go-runner-images-postsubmit-al-2023
-  cron: "0 20 * * 1-5"
+- name: go-runner-images-periodic-al-2023
+  cron: "0 23 * * 1-5"
   cluster: "prow-postsubmits-cluster"
   error_on_eviction: true
+  extra_refs:
+  - org: aws
+    repo: eks-distro-build-tooling
+    base_ref: main
   decoration_config:
     gcs_configuration:
       bucket: s3://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm
@@ -32,7 +36,7 @@ periodics:
     image-build: "true"
     disk-usage: "true"
   spec:
-    serviceaccountName: periodics-build-account
+    serviceaccountName: postsubmits-build-account
     automountServiceAccountToken: true
     nodeSelector:
       arch: AMD64
@@ -43,9 +47,11 @@ periodics:
       - bash
       - -c
       - >
-        trap 'touch /status/done' EXIT
+        trap '(docker buildx rm eks-d-builders || true) && touch /status/done' EXIT
         &&
         scripts/buildkit_check.sh
+        &&
+        scripts/setup_buildx.sh
         &&
         projects/go-runner/scripts/prow_release_images.sh
       env:
@@ -60,6 +66,10 @@ periodics:
       - name: ECR_PUBLIC_PUSH_ROLE_ARN
         value: "arn:aws:iam::832188789588:role/ECRPublicPushRole"
       - name: PUSH_IMAGES
+        value: "true"
+      - name: BUILDKITD_IMAGE
+        value: "moby/buildkit:v0.12.3-rootless"
+      - name: USE_BUILDX
         value: "true"
       resources:
         requests:

--- a/templater/jobs/periodic/eks-distro-build-tooling/go-runner-images-periodics-al-X.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/go-runner-images-periodics-al-X.yaml
@@ -1,7 +1,9 @@
-jobName: go-runner-images-postsubmit-al-{{ .alVersion }}
-cronExpression: 0 20 * * 1-5
+jobName: go-runner-images-periodic-al-{{ .alVersion }}
+cronExpression: 0 23 * * 1-5
 imageBuild: true
+useDockerBuildX: true
 automountServiceAccountToken: true
+serviceAccountName: postsubmits-build-account
 commands:
 - projects/go-runner/scripts/prow_release_images.sh
 projectPath: projects/go-runner
@@ -20,3 +22,7 @@ envVars:
   value: arn:aws:iam::832188789588:role/ECRPublicPushRole
 - name: PUSH_IMAGES
   value: true
+extraRefs:
+- baseRef: main
+  org: aws
+  repo: eks-distro-build-tooling


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Build [job](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/go-runner-images-postsubmit-al-2/2055015395705753600) failed with error
```
bash: scripts/buildkit_check.sh: No such file or directory
```
Fix: Added `useDockerBuildX: true`
* + minor changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
