### PR TITLE
Trigger base image rebuild on golang version updates

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-tooling-postsubmit-al-2
     always_run: false
-    run_if_changed: "^eks-distro-base/postsubmit_trigger$"
+    run_if_changed: "^eks-distro-base/(postsubmit_trigger|golang_versions.yaml)$"
     branches:
     - ^main$
     max_concurrency: 10

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2023.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits-al-2023.yaml
@@ -22,7 +22,7 @@ postsubmits:
   aws/eks-distro-build-tooling:
   - name: eks-distro-base-tooling-postsubmit-al-2023
     always_run: false
-    run_if_changed: "^eks-distro-base/postsubmit_trigger$"
+    run_if_changed: "^eks-distro-base/(postsubmit_trigger|golang_versions.yaml)$"
     branches:
     - ^main$
     max_concurrency: 10

--- a/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-al-X.yaml
+++ b/templater/jobs/postsubmit/eks-distro-build-tooling/eks-distro-base-postsubmits-al-X.yaml
@@ -1,5 +1,5 @@
 jobName: eks-distro-base-tooling-postsubmit-al-{{ .alVersion }}
-runIfChanged: ^eks-distro-base/postsubmit_trigger$
+runIfChanged: ^eks-distro-base/(postsubmit_trigger|golang_versions.yaml)$
 imageBuild: true
 prCreation: true
 architecture: AMD64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Triggers a full base image rebuild when a new Go version is merged, so iptables and other
consumers pick up the updated golang-compiler image automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
