### PR TITLE
fix: sync pr-bot fork in helm chart periodic

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/check-upstream-helm-chart-images.yaml
+++ b/jobs/aws/eks-distro-build-tooling/check-upstream-helm-chart-images.yaml
@@ -59,6 +59,8 @@ periodics:
         &&
         make check-external-dns-release -C projects/kubernetes-sigs/external-dns
         &&
+        ./pr-scripts/update_local_branch.sh eks-distro-build-tooling helm-chart-image-release
+        &&
         ./pr-scripts/create_pr.sh eks-distro-build-tooling helm-chart-image-tag helm-chart-image-release
       env:
       - name: PROJECT_PATH

--- a/templater/jobs/periodic/eks-distro-build-tooling/check-upstream-helm-chart-images.yaml
+++ b/templater/jobs/periodic/eks-distro-build-tooling/check-upstream-helm-chart-images.yaml
@@ -7,6 +7,7 @@ commands:
 - make check-prow-release -C projects/kubernetes/test-infra
 - make check-athens-release -C projects/gomods/athens
 - make check-external-dns-release -C projects/kubernetes-sigs/external-dns
+- ./pr-scripts/update_local_branch.sh eks-distro-build-tooling helm-chart-image-release
 - ./pr-scripts/create_pr.sh eks-distro-build-tooling helm-chart-image-tag helm-chart-image-release
 projectPath: projects/kubernetes/test-infra
 envVars:


### PR DESCRIPTION
The check-upstream-helm-chart-images periodic called create_pr.sh without first running update_local_branch.sh, so the eks-distro-pr-bot fork clone stayed on its stale main branch. New project directories not present in that stale checkout, such as projects/kubernetes-sigs/ external-dns, were missing, and create_pr.sh's `cp -f` into them failed with "No such file or directory" since cp will not create the parent directory.

Add the update_local_branch.sh call before create_pr.sh so the fork clone is reset to current upstream/main on the PR branch, matching every other PR-creating flow (update_helm_images.sh, update_base_image.sh, update_base_image_other_repos.sh).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
